### PR TITLE
Fix emit signal

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1112,7 +1112,7 @@ void UserMgr::initUserObjects(void)
 }
 
 UserMgr::UserMgr(sdbusplus::bus::bus &bus, const char *path) :
-    UserMgrIface(bus, path), AccountPolicyIface(bus, path), bus(bus), path(path)
+    Ifaces(bus, path, true), bus(bus), path(path)
 {
     UserMgrIface::allPrivileges(privMgr);
     std::sort(groupsMgr.begin(), groupsMgr.end());
@@ -1221,6 +1221,9 @@ UserMgr::UserMgr(sdbusplus::bus::bus &bus, const char *path) :
         AccountPolicyIface::accountUnlockTimeout(value32);
     }
     initUserObjects();
+
+    // emit the signal
+    this->emit_object_added();
 }
 
 } // namespace user

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -33,6 +33,9 @@ using UserSSHLists =
 using AccountPolicyIface =
     sdbusplus::xyz::openbmc_project::User::server::AccountPolicy;
 
+using Ifaces =
+    sdbusplus::server::object::object<UserMgrIface, AccountPolicyIface>;
+
 using Privilege = std::string;
 using GroupList = std::vector<std::string>;
 using UserEnabled = bool;
@@ -59,7 +62,7 @@ using DbusUserObj = std::map<DbusUserObjPath, DbusUserObjValue>;
 /** @class UserMgr
  *  @brief Responsible for managing user accounts over the D-Bus interface.
  */
-class UserMgr : public UserMgrIface, AccountPolicyIface
+class UserMgr : public Ifaces
 {
   public:
     UserMgr() = delete;

--- a/users.cpp
+++ b/users.cpp
@@ -55,15 +55,15 @@ using Argument = xyz::openbmc_project::Common::InvalidArgument;
 Users::Users(sdbusplus::bus::bus &bus, const char *path,
              std::vector<std::string> groups, std::string priv, bool enabled,
              UserMgr &parent) :
-    UsersIface(bus, path, true),
-    DeleteIface(bus, path),
+    UserIfaces(bus, path, true),
     userName(std::experimental::filesystem::path(path).filename()),
     manager(parent)
 {
     UsersIface::userPrivilege(priv, true);
     UsersIface::userGroups(groups, true);
     UsersIface::userEnabled(enabled, true);
-    UsersIface::emit_object_added();
+
+    this->emit_object_added();
 }
 
 /** @brief delete user method.

--- a/users.cpp
+++ b/users.cpp
@@ -55,7 +55,7 @@ using Argument = xyz::openbmc_project::Common::InvalidArgument;
 Users::Users(sdbusplus::bus::bus &bus, const char *path,
              std::vector<std::string> groups, std::string priv, bool enabled,
              UserMgr &parent) :
-    UserIfaces(bus, path, true),
+    Interfaces(bus, path, true),
     userName(std::experimental::filesystem::path(path).filename()),
     manager(parent)
 {

--- a/users.hpp
+++ b/users.hpp
@@ -30,7 +30,7 @@ using UsersIface =
     sdbusplus::server::object::object<Base::User::server::Attributes>;
 using DeleteIface =
     sdbusplus::server::object::object<Base::Object::server::Delete>;
-
+using UserIfaces = sdbusplus::server::object::object<UsersIface, DeleteIface>;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -39,7 +39,7 @@ class UserMgr; // Forward declaration for UserMgr.
 /** @class Users
  *  @brief Lists User objects and it's properties
  */
-class Users : public UsersIface, DeleteIface
+class Users : public UserIfaces
 {
   public:
     Users() = delete;

--- a/users.hpp
+++ b/users.hpp
@@ -26,11 +26,9 @@ namespace user
 {
 
 namespace Base = sdbusplus::xyz::openbmc_project;
-using UsersIface =
-    sdbusplus::server::object::object<Base::User::server::Attributes>;
-using DeleteIface =
-    sdbusplus::server::object::object<Base::Object::server::Delete>;
-using UserIfaces = sdbusplus::server::object::object<UsersIface, DeleteIface>;
+using UsersIface = Base::User::server::Attributes;
+using DeleteIface = Base::Object::server::Delete;
+using Interfaces = sdbusplus::server::object::object<UsersIface, DeleteIface>;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -39,7 +37,7 @@ class UserMgr; // Forward declaration for UserMgr.
 /** @class Users
  *  @brief Lists User objects and it's properties
  */
-class Users : public UserIfaces
+class Users : public Interfaces
 {
   public:
     Users() = delete;


### PR DESCRIPTION
This will fix the issue regarding authorisation, Currently with the user creation multiple interface added signal is getting emitted, and due to that bmcweb application get the interface added  signal for the object which is not fully populated, hence don't get the privilege for the user, so no HTTP operation gets supported through redfish.