### PR TITLE
Fix: Emit single interface added signal.

### DIFF
--- a/users.cpp
+++ b/users.cpp
@@ -55,7 +55,7 @@ using Argument = xyz::openbmc_project::Common::InvalidArgument;
 Users::Users(sdbusplus::bus::bus &bus, const char *path,
              std::vector<std::string> groups, std::string priv, bool enabled,
              UserMgr &parent) :
-    UserIfaces(bus, path, true),
+    Interfaces(bus, path, true),
     userName(std::experimental::filesystem::path(path).filename()),
     manager(parent)
 {

--- a/users.hpp
+++ b/users.hpp
@@ -26,11 +26,9 @@ namespace user
 {
 
 namespace Base = sdbusplus::xyz::openbmc_project;
-using UsersIface =
-    sdbusplus::server::object::object<Base::User::server::Attributes>;
-using DeleteIface =
-    sdbusplus::server::object::object<Base::Object::server::Delete>;
-using UserIfaces = sdbusplus::server::object::object<UsersIface, DeleteIface>;
+using UsersIface = Base::User::server::Attributes;
+using DeleteIface = Base::Object::server::Delete;
+using Interfaces = sdbusplus::server::object::object<UsersIface, DeleteIface>;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -39,7 +37,7 @@ class UserMgr; // Forward declaration for UserMgr.
 /** @class Users
  *  @brief Lists User objects and it's properties
  */
-class Users : public UserIfaces
+class Users : public Interfaces
 {
   public:
     Users() = delete;


### PR DESCRIPTION
This will fix the issue regarding authorisation, Currently with the user creation multiple interface added signal is getting emitted, and due to that bmcweb application get the interface added  signal for the object which is not fully populated, hence don't get the privilege for the user, so no HTTP operation gets supported through redfish.