### PR TITLE
LDAP: add support for privilege priv-noaccess

### DIFF
--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -271,8 +271,12 @@ class Config : public Ifaces
     std::map<Id, std::unique_ptr<LDAPMapperEntry>> PrivilegeMapperList;
 
     /** @brief available privileges container */
-    std::set<std::string> privMgr = {"priv-admin", "priv-operator", "priv-user",
-                                     "priv-callback"};
+    std::set<std::string> privMgr = {
+        "priv-admin",
+        "priv-operator",
+        "priv-user",
+        "priv-noaccess",
+    };
 
     /** @brief React to InterfaceAdded signal
      *  @param[in] msg - sdbusplus message

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -98,8 +98,12 @@ class LDAPMapperMgr : public MapperMgrIface
     std::string persistPath;
 
     /** @brief available privileges container */
-    std::set<std::string> privMgr = {"priv-admin", "priv-operator", "priv-user",
-                                     "priv-callback"};
+    std::set<std::string> privMgr = {
+        "priv-admin",
+        "priv-operator",
+        "priv-user",
+        "priv-noaccess",
+    };
 
     /** @brief Id of the last privilege mapper entry */
     Id entryId = 0;


### PR DESCRIPTION
This commit adds support to ldap privilege role map configuration
for 'priv-noaccess'

Signed-off-by: raviteja-b <raviteja28031990@gmail.com>
Change-Id: Ia28da61ee3f3bad8e2e233efd220266586713f4d