### PR TITLE
Add priv-OemIBMServiceAgent

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,7 +14,7 @@ Description of section entries:
 
     Section entries are structured according to the following scheme:
 
-    X:  NAME <EMAIL_USERNAME@DOMAIN> <IRC_USERNAME!>
+    X:  NAME <EMAIL_USERNAME@DOMAIN> <DISCORD_USERNAME!>
     X:  ...
     .
     .
@@ -24,10 +24,10 @@ Description of section entries:
     organization; FILE_PATH is a file path within the repository, possibly with
     wildcards; X is a tag of one of the following types:
 
-    M:  Denotes maintainer; has fields NAME <EMAIL_USERNAME@DOMAIN> <IRC_USERNAME!>;
+    M:  Denotes maintainer; has fields NAME <EMAIL_USERNAME@DOMAIN> <DISCORD_USERNAME!>;
         if omitted from an entry, assume one of the maintainers from the
         MAINTAINERS entry.
-    R:  Denotes reviewer; has fields NAME <EMAIL_USERNAME@DOMAIN> <IRC_USERNAME!>;
+    R:  Denotes reviewer; has fields NAME <EMAIL_USERNAME@DOMAIN> <DISCORD_USERNAME!>;
         these people are to be added as reviewers for a change matching the repo
         path.
     F:  Denotes forked from an external repository; has fields URL.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -42,5 +42,5 @@ Description of section entries:
 START OF MAINTAINERS LIST
 -------------------------
 
-M:  Ratan Gupta <ratagupt@linux.vnet.ibm.com> <rgupta!>
+M:  Ratan Gupta <ratankgupta31@gmail.com> <rgupta!>
 M:  Richard Thomaiyar <richard.marian.thomaiyar@linux.intel.com> <rthomaiy123!>

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,5 +22,28 @@ phosphor_user_manager_CXXFLAGS = $(SYSTEMD_CFLAGS) \
                                  -DBOOST_SYSTEM_NO_DEPRECATED \
                                  -DBOOST_ERROR_CODE_HEADER_ONLY
 
+certmgrenvdir=$(datadir)/phosphor-certificate-manager
+dbuspolicy_DATA = phosphor-nslcd-cert-config.conf
+certmgrenv_DATA = nslcd
+SYSTEM_UNIT_ALIASES = \
+	../phosphor-certificate-manager@.service multi-user.target.wants/phosphor-certificate-manager@nslcd.service
+
 SUBDIRS = . phosphor-ldap-mapper phosphor-ldap-config test
 
+install-aliases-hook:
+	set -- $(SYSTEM_UNIT_ALIASES) && \
+	  dir=$(systemdsystemunitdir) && $(install-aliases)
+
+define install-aliases
+  while [ -n "$$1" ]; do \
+	$(MKDIR_P) `dirname $(DESTDIR)$$dir/$$2` && \
+	rm -f $(DESTDIR)$$dir/$$2 && \
+	$(LN_S) $$1 $(DESTDIR)$$dir/$$2 && \
+	shift 2 || exit $$?; \
+  done
+endef
+
+INSTALL_DATA_HOOKS = \
+	install-aliases-hook
+
+install-data-hook: $(INSTALL_DATA_HOOKS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,28 +22,5 @@ phosphor_user_manager_CXXFLAGS = $(SYSTEMD_CFLAGS) \
                                  -DBOOST_SYSTEM_NO_DEPRECATED \
                                  -DBOOST_ERROR_CODE_HEADER_ONLY
 
-certmgrenvdir=$(datadir)/phosphor-certificate-manager
-dbuspolicy_DATA = phosphor-nslcd-cert-config.conf
-certmgrenv_DATA = nslcd
-SYSTEM_UNIT_ALIASES = \
-	../phosphor-certificate-manager@.service multi-user.target.wants/phosphor-certificate-manager@nslcd.service
-
 SUBDIRS = . phosphor-ldap-mapper phosphor-ldap-config test
 
-install-aliases-hook:
-	set -- $(SYSTEM_UNIT_ALIASES) && \
-	  dir=$(systemdsystemunitdir) && $(install-aliases)
-
-define install-aliases
-  while [ -n "$$1" ]; do \
-	$(MKDIR_P) `dirname $(DESTDIR)$$dir/$$2` && \
-	rm -f $(DESTDIR)$$dir/$$2 && \
-	$(LN_S) $$1 $(DESTDIR)$$dir/$$2 && \
-	shift 2 || exit $$?; \
-  done
-endef
-
-INSTALL_DATA_HOOKS = \
-	install-aliases-hook
-
-install-data-hook: $(INSTALL_DATA_HOOKS)

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,33 @@ AS_IF([test "x$enable_oe_sdk" == "xyes"],
     AC_SUBST([OESDK_TESTCASE_FLAGS], [$testcase_flags])
 )
 
+AC_ARG_WITH([systemdsystemunitdir],
+     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],
+     [],
+     [with_systemdsystemunitdir=auto]
+)
+AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"],
+    [def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
+           [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
+                  [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])]
+            )
+            with_systemdsystemunitdir=no],
+           [with_systemdsystemunitdir="$def_systemdsystemunitdir"]
+     )]
+)
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
+      [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])]
+)
+
+AC_ARG_WITH([dbuspolicydir],
+        AS_HELP_STRING([--with-dbuspolicydir=DIR], [D-Bus policy directory]),
+        [],
+        [with_dbuspolicydir=$($PKG_CONFIG --variable=sysconfdir dbus-1)/dbus-1/system.d])
+AS_IF([test "x$with_dbuspolicydir" != "xno"],
+      [AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])]
+)
+
 AC_ARG_VAR(LDAP_CONFIG_FILE, [Path of LDAP configuration file])
 AS_IF([test "x$LDAP_CONFIG_FILE" == "x"], [LDAP_CONFIG_FILE="/etc/nslcd.conf"])
 AC_DEFINE_UNQUOTED([LDAP_CONFIG_FILE], ["$LDAP_CONFIG_FILE"], [Path of LDAP configuration file])

--- a/configure.ac
+++ b/configure.ac
@@ -63,33 +63,6 @@ AS_IF([test "x$enable_oe_sdk" == "xyes"],
     AC_SUBST([OESDK_TESTCASE_FLAGS], [$testcase_flags])
 )
 
-AC_ARG_WITH([systemdsystemunitdir],
-     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],
-     [],
-     [with_systemdsystemunitdir=auto]
-)
-AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"],
-    [def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
-     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
-           [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
-                  [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])]
-            )
-            with_systemdsystemunitdir=no],
-           [with_systemdsystemunitdir="$def_systemdsystemunitdir"]
-     )]
-)
-AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
-      [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])]
-)
-
-AC_ARG_WITH([dbuspolicydir],
-        AS_HELP_STRING([--with-dbuspolicydir=DIR], [D-Bus policy directory]),
-        [],
-        [with_dbuspolicydir=$($PKG_CONFIG --variable=sysconfdir dbus-1)/dbus-1/system.d])
-AS_IF([test "x$with_dbuspolicydir" != "xno"],
-      [AC_SUBST([dbuspolicydir], [$with_dbuspolicydir])]
-)
-
 AC_ARG_VAR(LDAP_CONFIG_FILE, [Path of LDAP configuration file])
 AS_IF([test "x$LDAP_CONFIG_FILE" == "x"], [LDAP_CONFIG_FILE="/etc/nslcd.conf"])
 AC_DEFINE_UNQUOTED([LDAP_CONFIG_FILE], ["$LDAP_CONFIG_FILE"], [Path of LDAP configuration file])

--- a/nslcd
+++ b/nslcd
@@ -1,0 +1,9 @@
+#REST URI endpoint
+#example: /xyz/openbmc_project/certs/client/ldap
+ENDPOINT=ldap
+
+#Path for the certificate file
+CERTPATH=/etc/nslcd/certs/cert.pem
+
+#Type of the service client/server
+TYPE=client

--- a/nslcd
+++ b/nslcd
@@ -1,9 +1,0 @@
-#REST URI endpoint
-#example: /xyz/openbmc_project/certs/client/ldap
-ENDPOINT=ldap
-
-#Path for the certificate file
-CERTPATH=/etc/nslcd/certs/cert.pem
-
-#Type of the service client/server
-TYPE=client

--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -287,6 +287,7 @@ class Config : public Ifaces
         "priv-operator",
         "priv-user",
         "priv-noaccess",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief React to InterfaceAdded signal

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -105,6 +105,7 @@ class LDAPMapperMgr : public MapperMgrIface
         "priv-operator",
         "priv-user",
         "priv-noaccess",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief Id of the last privilege mapper entry */

--- a/phosphor-nslcd-cert-config.conf
+++ b/phosphor-nslcd-cert-config.conf
@@ -1,0 +1,8 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="xyz.openbmc_project.Certs.Manager.Client.Ldap"/>
+    <allow send_destination="xyz.openbmc_project.Certs.Manager.Client.Ldap"/>
+  </policy>
+</busconfig>

--- a/phosphor-nslcd-cert-config.conf
+++ b/phosphor-nslcd-cert-config.conf
@@ -1,8 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <policy user="root">
-    <allow own="xyz.openbmc_project.Certs.Manager.Client.Ldap"/>
-    <allow send_destination="xyz.openbmc_project.Certs.Manager.Client.Ldap"/>
-  </policy>
-</busconfig>

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -300,7 +300,7 @@ void UserMgr::createUser(std::string userName,
     throwForInvalidPrivilege(priv);
     throwForInvalidGroups(groupNames);
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     throwForUserExists(userName);
     throwForUserNameConstraints(userName, groupNames);
     throwForMaxGrpUserCount(groupNames);
@@ -346,7 +346,7 @@ void UserMgr::createUser(std::string userName,
 void UserMgr::deleteUser(std::string userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     try
     {
@@ -369,7 +369,7 @@ void UserMgr::deleteUser(std::string userName)
 void UserMgr::renameUser(std::string userName, std::string newUserName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     throwForUserExists(newUserName);
     throwForUserNameConstraints(newUserName,
@@ -410,7 +410,7 @@ void UserMgr::updateGroupsAndPriv(const std::string& userName,
     throwForInvalidPrivilege(priv);
     throwForInvalidGroups(groupNames);
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     const std::vector<std::string>& oldGroupNames =
         usersList[userName].get()->userGroups();
@@ -645,7 +645,7 @@ int UserMgr::setPamModuleArgValue(const std::string& moduleName,
 void UserMgr::userEnable(const std::string& userName, bool enabled)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     try
     {
@@ -678,7 +678,7 @@ static constexpr size_t t2OutputIndex = 1;
 bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     std::vector<std::string> output;
 
     output = executeCmd("/usr/sbin/pam_tally2", "-u", userName.c_str());
@@ -716,7 +716,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
                                          const bool& value)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     std::vector<std::string> output;
     if (value == true)
     {
@@ -735,7 +735,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
 bool UserMgr::userPasswordExpired(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
 
     struct spwd spwd
     {};
@@ -780,7 +780,7 @@ bool UserMgr::userPasswordExpired(const std::string& userName)
 UserSSHLists UserMgr::getUserAndSshGrpList()
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
 
     std::vector<std::string> userList;
     std::vector<std::string> sshUsersList;
@@ -838,7 +838,7 @@ size_t UserMgr::getIpmiUsersCount()
 bool UserMgr::isUserEnabled(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     std::array<char, 4096> buffer{};
     struct spwd spwd;
     struct spwd* resultPtr = nullptr;
@@ -1105,7 +1105,7 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
 void UserMgr::initUserObjects(void)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock{};
+    // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     std::vector<std::string> userNameList;
     std::vector<std::string> sshGrpUsersList;
     UserSSHLists userSSHLists = getUserAndSshGrpList();

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -300,7 +300,7 @@ void UserMgr::createUser(std::string userName,
     throwForInvalidPrivilege(priv);
     throwForInvalidGroups(groupNames);
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     throwForUserExists(userName);
     throwForUserNameConstraints(userName, groupNames);
     throwForMaxGrpUserCount(groupNames);
@@ -346,7 +346,7 @@ void UserMgr::createUser(std::string userName,
 void UserMgr::deleteUser(std::string userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     try
     {
@@ -369,7 +369,7 @@ void UserMgr::deleteUser(std::string userName)
 void UserMgr::renameUser(std::string userName, std::string newUserName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     throwForUserExists(newUserName);
     throwForUserNameConstraints(newUserName,
@@ -410,7 +410,7 @@ void UserMgr::updateGroupsAndPriv(const std::string& userName,
     throwForInvalidPrivilege(priv);
     throwForInvalidGroups(groupNames);
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     const std::vector<std::string>& oldGroupNames =
         usersList[userName].get()->userGroups();
@@ -645,7 +645,7 @@ int UserMgr::setPamModuleArgValue(const std::string& moduleName,
 void UserMgr::userEnable(const std::string& userName, bool enabled)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     throwForUserDoesNotExist(userName);
     try
     {
@@ -678,7 +678,7 @@ static constexpr size_t t2OutputIndex = 1;
 bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     std::vector<std::string> output;
 
     output = executeCmd("/usr/sbin/pam_tally2", "-u", userName.c_str());
@@ -716,7 +716,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
                                          const bool& value)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     std::vector<std::string> output;
     if (value == true)
     {
@@ -735,7 +735,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
 bool UserMgr::userPasswordExpired(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
 
     struct spwd spwd
     {};
@@ -780,7 +780,7 @@ bool UserMgr::userPasswordExpired(const std::string& userName)
 UserSSHLists UserMgr::getUserAndSshGrpList()
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
 
     std::vector<std::string> userList;
     std::vector<std::string> sshUsersList;
@@ -838,7 +838,7 @@ size_t UserMgr::getIpmiUsersCount()
 bool UserMgr::isUserEnabled(const std::string& userName)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     std::array<char, 4096> buffer{};
     struct spwd spwd;
     struct spwd* resultPtr = nullptr;
@@ -1105,7 +1105,7 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
 void UserMgr::initUserObjects(void)
 {
     // All user management lock has to be based on /etc/shadow
-    phosphor::user::shadow::Lock lock();
+    phosphor::user::shadow::Lock lock{};
     std::vector<std::string> userNameList;
     std::vector<std::string> sshGrpUsersList;
     UserSSHLists userSSHLists = getUserAndSshGrpList();

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -196,7 +196,8 @@ class UserMgr : public Ifaces
 
     /** @brief privilege manager container */
     std::vector<std::string> privMgr = {"priv-admin", "priv-operator",
-                                        "priv-user", "priv-noaccess"};
+                                        "priv-user", "priv-noaccess",
+                                        "priv-oemibmserviceagent"};
 
     /** @brief groups manager container */
     std::vector<std::string> groupsMgr = {"web", "redfish", "ipmi", "ssh"};


### PR DESCRIPTION
This commit adds the privilege group for the custom
OemIBMServiceAgent role.  The recipe changes add the group itself
and are a pre-requisite for this change.

This does not attempt to restrict any use of the new role.

Tested:
Phosphor user manager starts without crashing and uses the new group.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>