### PR TITLE
Add priv-OemIBMServiceAgent

### DIFF
--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -278,6 +278,7 @@ class Config : public Ifaces
         "priv-operator",
         "priv-user",
         "priv-noaccess",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief React to InterfaceAdded signal

--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -274,11 +274,8 @@ class Config : public Ifaces
 
     /** @brief available privileges container */
     std::set<std::string> privMgr = {
-        "priv-admin",
-        "priv-operator",
-        "priv-user",
-        "priv-noaccess",
-        "priv-oemibmserviceagent",
+        "priv-admin",    "priv-operator",           "priv-user",
+        "priv-noaccess", "priv-oemibmserviceagent",
     };
 
     /** @brief React to InterfaceAdded signal

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -101,11 +101,8 @@ class LDAPMapperMgr : public MapperMgrIface
 
     /** @brief available privileges container */
     std::set<std::string> privMgr = {
-        "priv-admin",
-        "priv-operator",
-        "priv-user",
-        "priv-noaccess",
-        "priv-oemibmserviceagent",
+        "priv-admin",    "priv-operator",           "priv-user",
+        "priv-noaccess", "priv-oemibmserviceagent",
     };
 
     /** @brief Id of the last privilege mapper entry */

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -105,6 +105,7 @@ class LDAPMapperMgr : public MapperMgrIface
         "priv-operator",
         "priv-user",
         "priv-noaccess",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief Id of the last privilege mapper entry */

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -196,7 +196,8 @@ class UserMgr : public Ifaces
 
     /** @brief privilege manager container */
     std::vector<std::string> privMgr = {"priv-admin", "priv-operator",
-                                        "priv-user", "priv-noaccess"};
+                                        "priv-user", "priv-noaccess",
+                                        "priv-oemibmserviceagent"};
 
     /** @brief groups manager container */
     std::vector<std::string> groupsMgr = {"web", "redfish", "ipmi", "ssh"};


### PR DESCRIPTION
This commit adds the privilege group for the custom
OemIBMServiceAgent role.  The recipe changes add the group itself
and are a pre-requisite for this change.

This does not attempt to restrict any use of the new role.

Tested:
Phosphor user manager starts without crashing and uses the new group.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>