### PR TITLE
Fix UserLockedForFailedAttempt for locked users

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -698,14 +698,23 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
     // If there is an error, the message is like this:
     // /usr/sbin/faillock: Error clearing the tally file for {user}:{output from
     // perror}
-    int failedAttempts = output.size() - 2;
-
-    if (AccountPolicyIface::maxLoginAttemptBeforeLockout() != 0 &&
-        failedAttempts >= AccountPolicyIface::maxLoginAttemptBeforeLockout())
+    if (output.size() < 2)
     {
         log<level::ERR>("faillock resulted in error",
                         entry("USER=%s", userName.c_str()));
+        if (output.size() >= 1)
+        {
+            log<level::ERR>("faillock error message",
+                            entry("message=%s", output[0].c_str()));
+        }
         elog<InternalFailure>();
+    }
+
+    int failedAttempts = output.size() - 2;
+    if (AccountPolicyIface::maxLoginAttemptBeforeLockout() != 0 &&
+        failedAttempts >= AccountPolicyIface::maxLoginAttemptBeforeLockout())
+    {
+        return true; // User account password is locked
     }
     return false; // User account password is un-locked
 }

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -695,9 +695,11 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
     // > "When        Type    Source          Valid"
     // > ${timestamp} ${type} {RHOST,TTY,SVC} {V,I}
     //
-    // If there is an error, the message is like this:
+    // If there is an error, the output is a single line like this:
     // /usr/sbin/faillock: Error clearing the tally file for {user}:{output from
     // perror}
+    // Example: /usr/sbin/faillock: Error opening the tally file for admin:Not
+    // a directory
     if (output.size() < 2)
     {
         log<level::ERR>("faillock resulted in error",
@@ -705,7 +707,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
         if (output.size() >= 1)
         {
             log<level::ERR>("faillock error message",
-                            entry("message=%s", output[0].c_str()));
+                            entry("ERROR=%s", output[0].c_str()));
         }
         elog<InternalFailure>();
     }


### PR DESCRIPTION
This fixes a bug getting the `xyz.openbmc_project.User.Attributes` property `UserLockedForFailedAttempt` when a password is locked.
This bug causes the phosphor Web app > Menu > Security and access > User Management page to show no users, not allow users to be created, etc.

This bug only happens when the `xyz.openbmc_project.User.AccountPolicy` `MaxLoginAttemptBeforeLockout` property has a nonzero value and a user has exceeded the failure count.  (The default for IBM systems is 5.)

This bug was introduced in 87a6ab71de880d5e28b95a2077cb9d2758e037d9 titled "Adapt to OpenBMC's Linux-PAM module changes".

Also fixed: This enhanced the journal logging when the `faillock` command fails with an error message.  The error reported by faillock is written to the journal.

If this problem happens to you, and the fix is not in the system, login as root and use the `faillock --user USER --reset` command (for all locked USERs) to recover.  If the fix is on your system, no action is needed.

Tested:
1. Locked a user (via the "login" command) by failing to login 5 times, and ensure that faillock reported 5 failed attempts, and the D-Bus interface returnes the true value for the UserLockedForFailedAttempt property.
```
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin
```

2. Removed the faillock file and observed the command failure, D-bus failure, and resulting journal entry.
```
Change the faillock directory to a plain file:
# mv /var/run/faillock /var/run/faillock-real
# touch /var/run/faillock
# faillock
faillock: Error reading tally directory: Not a directory
# busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin
Failed to get all properties on interface
  xyz.openbmc_project.User.Attributes: The operation failed internally.
# journalctl (selected entries):
phosphor-user-manager: /usr/sbin/faillock: Error opening the tally file for admin:Not a directory
phosphor-user-manager: The operation failed internally.

Then to recover:
# rm /var/run/faillock
# mv /var/run/faillock-real /var/run/faillock
```

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>