### PR TITLE
Add port validation for ldap server uri

### DIFF
--- a/phosphor-ldap-config/utils.cpp
+++ b/phosphor-ldap-config/utils.cpp
@@ -32,6 +32,11 @@ bool isValidLDAPURI(const std::string& URI, const char* scheme)
     {
         return false;
     }
+    if (ludppPtr->lud_port <= 0 || ludppPtr->lud_port > 65536)
+    {
+        return false;
+    }
+
     addrinfo hints{};
     addrinfo* servinfo = nullptr;
     hints.ai_family = AF_UNSPEC;


### PR DESCRIPTION
When a user sets the LDAP server URI with invalid port - value
either less than 0 or greater than 65536, the service should
return error instead of accepting invalid values.

Tested By:

* Before having this change:

busctl set-property xyz.openbmc_project.Ldap.Config \
/xyz/openbmc_project/user/ldap/active_directory \
xyz.openbmc_project.User.Ldap.Config LDAPServerURI \
s "ldap://9.194.251.141:-389"

xyz.openbmc_project.User.Ldap.Config     interface -         -                                        -
.GroupNameAttribute                      property  s         ""                                       emits-change writable
.LDAPBaseDN                              property  s         ""                                       emits-change writable
.LDAPBindDN                              property  s         ""                                       emits-change writable
.LDAPBindDNPassword                      property  s         ""                                       emits-change writable
.LDAPSearchScope                         property  s         "xyz.openbmc_project.User.Ldap.Config.S… emits-change writable
.LDAPServerURI                           property  s         "ldap://9.194.251.141:-389"              emits-change writable
.LDAPType                                property  s         "xyz.openbmc_project.User.Ldap.Config.T… emits-change writable

* After this change:

busctl set-property xyz.openbmc_project.Ldap.Config \
/xyz/openbmc_project/user/ldap/active_directory \
xyz.openbmc_project.User.Ldap.Config LDAPServerURI \
s "ldap://9.194.251.141:-389"

Failed to set property LDAPServerURI on interface xyz.openbmc_project.User.Ldap.Config: Invalid argument was given.

busctl set-property xyz.openbmc_project.Ldap.Config \
/xyz/openbmc_project/user/ldap/active_directory \
xyz.openbmc_project.User.Ldap.Config LDAPServerURI \
s "ldap://9.194.251.141:66000"

Failed to set property LDAPServerURI on interface xyz.openbmc_project.User.Ldap.Config: Invalid argument was given.

Signed-off-by: Asmitha Karunanithi <asmitk01@in.ibm.com>
Change-Id: Iee8eab7faf8ede9612f74a90b0e253614f3f4061