### PR TITLE
Restrict priv-oemibmserviceagent role

### DIFF
--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -284,7 +284,8 @@ class UserMgr : public Ifaces
     void throwForRestrictedPrivilegeRole(const std::string& priv);
 
     /** @brief check if a user has a RestrictedRole
-     *  method to check if the user's role is restricted, and throw if restricted
+     *  method to check if the user's role is restricted, and throw if
+     *  restricted
      *
      *  @param[in] userName - the name of the user
      */

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -276,6 +276,20 @@ class UserMgr : public Ifaces
      */
     void throwForInvalidGroups(const std::vector<std::string>& groupName);
 
+    /** @brief check for a RestrictedRole
+     *  method to check if the role is restricted, and throw if restricted
+     *
+     *  @param[in] priv - privilege role specified
+     */
+    void throwForRestrictedPrivilegeRole(const std::string& priv);
+
+    /** @brief check if a user has a RestrictedRole
+     *  method to check if the user's role is restricted, and throw if restricted
+     *
+     *  @param[in] userName - the name of the user
+     */
+    void throwForRestrictedUserPrivilegeRole(const std::string& userName);
+
     /** @brief get user enabled state
      *  method to get user enabled state.
      *


### PR DESCRIPTION
This enhances the user manager to handle the priv-oemibmserviceagent privilege role as a Redfish RestrictedRole.  This role is not allowed to be used in most operations, and users who have this role are not allowed to be modified for most operations.

Enhanced operations and interfaces are:
- xyz.openbmc_project.User.Manager createUser
- call xyz.openbmc_project.Object.Delete Delete
- call xyz.openbmc_project.User.Manager RenameUser
- set-property xyz.openbmc_project.User.Attributes UserGroups
- set-property xyz.openbmc_project.User.Attributes UserPrivilege

The following are allowed for users with RestrictedRole:
- set-property xyz.openbmc_project.User.Attributes UserLockedForFailedAttempt
- set-property xyz.openbmc_project.User.Attributes UserEnabled

Tested:

Basic function still works
busctl tree xyz.openbmc_project.User.Manager
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin

Create admin2 user
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user xyz.openbmc_project.User.Manager CreateUser sassb admin2 3 "redfish" "ssh" "web" priv-admin true
RESULT: admin2 user was created
RESULT: success

Change admin2 user to priv-oemibmserviceagent - must fail
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2 xyz.openbmc_project.User.Attributes UserPrivilege s priv-oemibmserviceagent
Failed to set property UserPrivilege on interface xyz.openbmc_project.User.Attributes: Invalid argument was given.
Journal: Restricted role
RESULT: success

Delete admin2 user
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2 xyz.openbmc_project.Object.Delete Delete
RESULT: successfully deleted
RESULT: success

Create service2 user must fail
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user xyz.openbmc_project.User.Manager CreateUser sassb servicenew 3 "redfish" "ssh" "web" priv-oemibmserviceagent true
Call failed: Invalid argument was given
RESULT: success!

Delete service user must fail
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service xyz.openbmc_project.Object.Delete Delete
Oops, the delete issued: Call failed: Remote peer disconnected
Journal contains: User has restricted role and: The operation failed internally.
RESULT: SUCCESS

Rename service user must fail
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user xyz.openbmc_project.User.Manager RenameUser ss service servicex
Call failed: The operation failed internally.
Journal contains: User has restricted role and: The operation failed internally.
User was not renamed
RESULT: Successful

Change service user groups must fail
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service xyz.openbmc_project.User.Attributes UserGroups as 2 "redfish" "ssh"
Failed to set property UserGroups on interface xyz.openbmc_project.User.Attributes: The operation failed internally.
journal entries: Restricted role
RESULT: Successful

Change service user privilege role must fail
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service xyz.openbmc_project.User.Attributes UserPrivilege s priv-admin
Output: Failed to set property UserPrivilege on interface xyz.openbmc_project.User.Attributes: Invalid argument was given.
Journal: User has restricted role and: The operation failed internally.
RESULT: Successful

UserLockedForFailedAttempt password unlock is allowed
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin xyz.openbmc_project.User.Attributes UserLockedForFailedAttempt b false
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service xyz.openbmc_project.User.Attributes UserLockedForFailedAttempt b false
RESULT: Successful

Disabling and re-enabling user accounts is allowed:
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/service xyz.openbmc_project.User.Attributes UserEnabled b false
Journal shows related entries nscd: monitored file `/etc/passwd` was written to
RESULT: Successful

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>