### PR TITLE
Do not allow the NoAccess role

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -279,6 +279,13 @@ void UserMgr::throwForInvalidPrivilege(const std::string& priv)
         elog<InvalidArgument>(Argument::ARGUMENT_NAME("Privilege"),
                               Argument::ARGUMENT_VALUE(priv.c_str()));
     }
+
+    if (priv == "priv-noaccess")
+    {
+        log<level::ERR>("The NoAccess privilege is not allowed");
+        elog<InvalidArgument>(Argument::ARGUMENT_NAME("Privilege"),
+                              Argument::ARGUMENT_VALUE(priv.c_str()));
+    }
 }
 
 void UserMgr::throwForInvalidGroups(const std::vector<std::string>& groupNames)


### PR DESCRIPTION
This makes the NoAccess role (priv-noaccess privilege group) unusable for new users and to change existing users to.  This role is deprecated and should not be used.

If you want to disable a user account, set Enabled = false.

Tested: via busctl
Regression: Was able to create a new user, and change to priv-operator
Tried to create a user with priv-no-access.
Tried to change a user to priv-noaccess.

busctl tree xyz.openbmc_project.User.Manager
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user

Create noaccess user - expect failure
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user xyz.openbmc_project.User.Manager CreateUser sassb noaccess 3 "redfish" "ssh" "web" priv-noaccess true
Call failed: Invalid argument was given.
The journal shows: The NoAccess privilege is not allowed
the user was not created

Create admin2 user
busctl call xyz.openbmc_project.User.Manager /xyz/openbmc_project/user xyz.openbmc_project.User.Manager CreateUser sassb admin2 3 "redfish" "ssh" "web" priv-admin true
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2

Change to priv-operator
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2 xyz.openbmc_project.User.Attributes UserPrivilege s priv-operator
busctl introspect xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2

Change to priv-noaccess - expect failure
busctl set-property xyz.openbmc_project.User.Manager /xyz/openbmc_project/user/admin2 xyz.openbmc_project.User.Attributes UserPrivilege s priv-noaccess
Failed to set property UserPrivilege on interface xyz.openbmc_project.User.Attributes: Invalid argument was given.
journal shows: phosphor-user-manager[483]: The NoAccess privilege is not allowed
The user was not changed

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>