### PR TITLE
Remove support for priv-noaccess role

### DIFF
--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -274,8 +274,10 @@ class Config : public Ifaces
 
     /** @brief available privileges container */
     std::set<std::string> privMgr = {
-        "priv-admin",    "priv-operator",           "priv-user",
-        "priv-noaccess", "priv-oemibmserviceagent",
+        "priv-admin",
+        "priv-operator",
+        "priv-user",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief React to InterfaceAdded signal

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -101,8 +101,10 @@ class LDAPMapperMgr : public MapperMgrIface
 
     /** @brief available privileges container */
     std::set<std::string> privMgr = {
-        "priv-admin",    "priv-operator",           "priv-user",
-        "priv-noaccess", "priv-oemibmserviceagent",
+        "priv-admin",
+        "priv-operator",
+        "priv-user",
+        "priv-oemibmserviceagent",
     };
 
     /** @brief Id of the last privilege mapper entry */

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -196,8 +196,7 @@ class UserMgr : public Ifaces
 
     /** @brief privilege manager container */
     std::vector<std::string> privMgr = {"priv-admin", "priv-operator",
-                                        "priv-user", "priv-noaccess",
-                                        "priv-oemibmserviceagent"};
+                                        "priv-user", "priv-oemibmserviceagent"};
 
     /** @brief groups manager container */
     std::vector<std::string> groupsMgr = {"web", "redfish", "ipmi", "ssh"};


### PR DESCRIPTION
This PR reverts two commits that added support for ldap priv-noaccess role

https://github.com/ibm-openbmc/phosphor-user-manager/commit/fe720ffacd180f866fbeb7ef8d3a5f243b328ccd
https://github.com/ibm-openbmc/phosphor-user-manager/blob/7c6e7cffaf061aabfe5489ef52442e2f7cbd0fb7/user_mgr.hpp