### PR TITLE
restrict the priv-operator role

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -295,9 +295,17 @@ void UserMgr::throwForInvalidGroups(const std::vector<std::string>& groupNames)
     }
 }
 
+/* Notes for restricted priv-operator role:
+ * 
+ * The priv-operator role is restricted so you cannot create an operator user
+ * or change an existing user to have the operator role.  However, if there
+ * happens to be a user with the operator role, you are allowed to rename or
+ * delete that user, or change them away from the operator role.
+ */
 void UserMgr::throwForRestrictedPrivilegeRole(const std::string& priv)
 {
-    if (priv == "priv-oemibmserviceagent")
+    if ((priv == "priv-oemibmserviceagent") ||
+        (priv == "priv-operator"))
     {
         log<level::ERR>("Restricted role");
         elog<InternalFailure>();


### PR DESCRIPTION
This restricts the priv-operator role so it cannot be used to create new users or change existing users.
It does not restrict user management on existing users who have the operator role: they can still be renamed, deleted, or changed.

Tested:
Tested the above scenarios.
Also tested priv-oemibmserviceagent is still restricted.
Also tested admin and readonly user can be created.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>