### PR TITLE
sdbusplus: object: don't use 'bool' argument constructor

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -57,7 +57,7 @@ Config::Config(sdbusplus::bus::bus& bus, const char* path, const char* filePath,
                ConfigIface::Type ldapType, bool ldapServiceEnabled,
                std::string userNameAttr, std::string groupNameAttr,
                ConfigMgr& parent) :
-    Ifaces(bus, path, true),
+    Ifaces(bus, path, Ifaces::action::defer_emit),
     secureLDAP(secureLDAP), ldapBindPassword(std::move(ldapBindDNPassword)),
     tlsCacertFile(caCertFile), tlsCertFile(certFile), configFilePath(filePath),
     objectPath(path), bus(bus), parent(parent),
@@ -109,7 +109,7 @@ Config::Config(sdbusplus::bus::bus& bus, const char* path, const char* filePath,
 Config::Config(sdbusplus::bus::bus& bus, const char* path, const char* filePath,
                const char* caCertFile, const char* certFile,
                ConfigIface::Type ldapType, ConfigMgr& parent) :
-    Ifaces(bus, path, true),
+    Ifaces(bus, path, Ifaces::action::defer_emit),
     secureLDAP(false), tlsCacertFile(caCertFile), tlsCertFile(certFile),
     configFilePath(filePath), objectPath(path), bus(bus), parent(parent),
     certificateInstalledSignal(

--- a/phosphor-ldap-config/ldap_config_mgr.hpp
+++ b/phosphor-ldap-config/ldap_config_mgr.hpp
@@ -56,7 +56,7 @@ class ConfigMgr : public CreateIface
     ConfigMgr(sdbusplus::bus::bus& bus, const char* path, const char* filePath,
               const char* dbusPersistentPath, const char* caCertFile,
               const char* certFile) :
-        CreateIface(bus, path, true),
+        CreateIface(bus, path, CreateIface::action::defer_emit),
         dbusPersistentPath(dbusPersistentPath), configFilePath(filePath),
         tlsCacertFile(caCertFile), tlsCertFile(certFile), bus(bus)
     {}

--- a/phosphor-ldap-config/ldap_mapper_entry.cpp
+++ b/phosphor-ldap-config/ldap_mapper_entry.cpp
@@ -27,7 +27,7 @@ LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
                                  const char* filePath,
                                  const std::string& groupName,
                                  const std::string& privilege, Config& parent) :
-    Interfaces(bus, path, true),
+    Interfaces(bus, path, Interfaces::action::defer_emit),
     id(std::stol(std::filesystem::path(path).filename())), manager(parent),
     persistPath(filePath)
 {
@@ -38,7 +38,7 @@ LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
 
 LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
                                  const char* filePath, Config& parent) :
-    Interfaces(bus, path, true),
+    Interfaces(bus, path, Interfaces::action::defer_emit),
     id(std::stol(std::filesystem::path(path).filename())), manager(parent),
     persistPath(filePath)
 {}

--- a/phosphor-ldap-mapper/ldap_mapper_entry.cpp
+++ b/phosphor-ldap-mapper/ldap_mapper_entry.cpp
@@ -28,7 +28,7 @@ LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
                                  const std::string& groupName,
                                  const std::string& privilege,
                                  LDAPMapperMgr& parent) :
-    Ifaces(bus, path, true),
+    Ifaces(bus, path, Ifaces::action::defer_emit),
     id(std::stol(std::filesystem::path(path).filename())), manager(parent),
     persistPath(filePath)
 {
@@ -39,7 +39,7 @@ LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
 
 LDAPMapperEntry::LDAPMapperEntry(sdbusplus::bus::bus& bus, const char* path,
                                  const char* filePath, LDAPMapperMgr& parent) :
-    Ifaces(bus, path, true),
+    Ifaces(bus, path, Ifaces::action::defer_emit),
     id(std::stol(std::filesystem::path(path).filename())), manager(parent),
     persistPath(filePath)
 {}

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1215,7 +1215,7 @@ void UserMgr::initUserObjects(void)
 }
 
 UserMgr::UserMgr(sdbusplus::bus::bus& bus, const char* path) :
-    Ifaces(bus, path, true), bus(bus), path(path)
+    Ifaces(bus, path, Ifaces::action::defer_emit), bus(bus), path(path)
 {
     UserMgrIface::allPrivileges(privMgr);
     std::sort(groupsMgr.begin(), groupsMgr.end());

--- a/users.cpp
+++ b/users.cpp
@@ -61,7 +61,7 @@ using Argument = xyz::openbmc_project::Common::InvalidArgument;
 Users::Users(sdbusplus::bus::bus& bus, const char* path,
              std::vector<std::string> groups, std::string priv, bool enabled,
              UserMgr& parent) :
-    Interfaces(bus, path, true),
+    Interfaces(bus, path, Interfaces::action::defer_emit),
     userName(std::filesystem::path(path).filename()), manager(parent)
 {
     UsersIface::userPrivilege(priv, true);


### PR DESCRIPTION
`sdbusplus::server::object_t` has long had an enum-based parameter for
signal action, but maintained a backwards compatible boolean mapping.
It is time to remove this boolean to make it more observable which
actions are being used in applications.  Map all `true` occurrences to
`action::defer_emit`.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
Change-Id: I6de31883b9f6a9a3115ae232575dffbdf652e0bd
Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>

Fixed trivial merge conflict with: users.cpp

The upstream commit is https://github.com/openbmc/phosphor-user-manager/commit/224559b478868886522a89b769530519ff926869