### PR TITLE
Update to fix SW544220

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -258,8 +258,7 @@ void UserMgr::throwForMaxGrpUserCount(
     }
     else
     {
-        if (usersList.size() > 0 && (usersList.size() - getIpmiUsersCount()) >=
-                                        (maxSystemUsers - ipmiMaxUsers))
+        if (usersList.size() > 0 && (usersList.size() >= maxSystemUsers))
         {
             log<level::ERR>("Non-ipmi User limit reached");
             elog<NoResource>(


### PR DESCRIPTION
The number of users was limited to 17 users 
and not the maximum of 30. 

A seperate PR for bwcweb  fixes the
problem that included redfish users
in the IPMI group which is limited to 15 users.

Tested: Three IPMI users existed on the system.
A service user existed on the system. A script
was run to create 30 more redfish users. The system
allowed the creation of 26 redfish users for a total
of 30 users.

tippolit@gfwa166:/Code/openbmc/build/p10bmc$ curl -k -X
GET https://service:0penBmc0@ever8bmc:18080/redfish/v1
/AccountService/Accounts
{
"@odata.id": "/redfish/v1/AccountService/Accounts",
"@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
"Description": "BMC User Accounts",
"Members": [
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest5"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest19"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest18"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest22"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest20"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest12"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest21"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest1"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest25"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/admin"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest2"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest23"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest3"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest26"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest13"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest11"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest4"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/ipmi2"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest24"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest14"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest6"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest15"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest10"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/ipmi1"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/service"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest17"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest8"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest9"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest7"
},
{
"@odata.id": "/redfish/v1/AccountService/Accounts/UserTest16"
}
],
"Members@odata.count": 30,
"Name": "Accounts Collection"
}tippolit@gfwa166:/Code/openbmc/build/p10bmc$

Signed-off-by: Tom Ippolito <thomas.ippolito@ibm.com>