### PR TITLE
Add ssh users to hostconsoleaccess group

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -341,7 +341,7 @@ void UserMgr::createUser(std::string userName,
     // In the OpenBMC community project:
     //   A. It allows access to the BMC's SSH interfaces
     //       - SSH port 22 reaches the BMC's command shell.
-    //       - SSH port 2200 reaches the host console.    
+    //       - SSH port 2200 reaches the host console.
     //   B. It is enforced by two mechanisms:
     //       1. The SSH dropbear server command uses the -G priv-admin argument
     //          to restrict SSH access to users who are in the priv-admin Linux

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -335,7 +335,53 @@ void UserMgr::createUser(std::string userName,
     throwForMaxGrpUserCount(groupNames);
 
     std::string groups = getCSVFromVector(groupNames);
+
+    // The "ssh" phosphor-privilege group controls access to the host console
+    // via SSH port 2200 and has a special implementation.
+    // In the OpenBMC community project:
+    //   A. It allows access to the BMC's SSH interfaces
+    //       - SSH port 22 reaches the BMC's command shell.
+    //       - SSH port 2200 reaches the host console.    
+    //   B. It is enforced by two mechanisms:
+    //       1. The SSH dropbear server command uses the -G priv-admin argument
+    //          to restrict SSH access to users who are in the priv-admin Linux
+    //          group.
+    //       2. The Linux user's login shell was set to /bin/sh (when "ssh" was
+    //          specified) or /bin/nologin (when "ssh" is not specified).
+    //          Having loginShell=/bin/sh is required to be able to get in
+    //          through the SSH interface.  The condition (loginShell==/bin/sh)
+    //          is equivalent to being in the "ssh" privilege-group.
+    //       Note there is no "ssh" Linux group.
+    // For p10bmc:
+    //   A. Additionally:
+    //       - SSH port 2201 to reaches the hypervisor console (PHYP).
+    //   B. We created three new Linux groups to control access to the SSH
+    //         destinations:
+    //       - SSH port 22 is controlled by membership in "bmcshellaccess".
+    //         Only the special service user should be in this group.
+    //       - SSH port 2200 is controlled by membership in "hostconsoleaccess"
+    //         All users (including the service user) should be in this group.
+    //       - SSH port 2201 is controlled by membership in the
+    //         "hypervisorconsoleaccess" group.
+    //         Only the special service user should be in this group.
+    //   The special handling in this code when the user is in the "ssh" group
+    //   (represented here as sshRequested):
+    //    1. Add the user to the hostconsoleaccess Linux group.
+    //    2. Set the user's login shell (as /bin/sh).
+    //   Note: No special code is needed to handle the special "service" user
+    //         because priv-oemibmserviceagent is a restricted role which means
+    //         the service agent's groups cannot be changed.
+    //   It remains up the BMC administrator to give "ssh" access to whichever
+    //   users they want (for example, to admin users).
     bool sshRequested = removeStringFromCSV(groups, grpSsh);
+    if (sshRequested)
+    {
+        if (groups.size() != 0)
+        {
+            groups += ",";
+        }
+        groups += "hostconsoleaccess";
+    }
 
     // treat privilege as a group - This is to avoid using different file to
     // store the same.
@@ -460,7 +506,16 @@ void UserMgr::updateGroupsAndPriv(const std::string& userName,
     }
 
     std::string groups = getCSVFromVector(groupNames);
+    // The "ssh" phosphor privilege group is handled specially
     bool sshRequested = removeStringFromCSV(groups, grpSsh);
+    if (sshRequested)
+    {
+        if (groups.size() != 0)
+        {
+            groups += ",";
+        }
+        groups += "hostconsoleaccess";
+    }
 
     // treat privilege as a group - This is to avoid using different file to
     // store the same.


### PR DESCRIPTION
Users who are in the Phosphor "ssh" group are intended to have access to the host console via SSH port 2200.  Users in the "ssh" phosphor privilege group are added to the "hostconsoleaccess" Linux group.

Tested:
1. Create new user in the "ssh" group and ensure they are in the hostconsoleaccess Linux group and can use ssh port 2200.
2. Change a user to the "ssh" group and ensure they are in the hostconsoleaccess group and can use ssh.
3. Remove user from the "ssh" group and ensure they are removed from the hostconsoleaccess group and cannot ssh.
4. Create new user not in the "ssh" group and ensure they are not in the hostconsoleaccess Linux group and cannot use ssh port 2200.

Use journalctl --follow to monitor.  Look for:
PAM password auth succeeded for 'admin'
PAM password auth succeeded for 'newuser2'
Logins are restricted to the group hostconsoleaccess but user 'newuser'
is not a member
grep newuser /etc/passwd verify the shell /bin/nologin or /bin/sh

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>