### PR TITLE
Add support for deleting authentication failure record files

### DIFF
--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -269,6 +269,9 @@ class UserMgrInTest : public testing::Test, public UserMgr
 
         ON_CALL(*this, executeUserDelete).WillByDefault(testing::Return());
 
+        ON_CALL(*this, executeUserClearFailRecords)
+            .WillByDefault(testing::Return());
+
         ON_CALL(*this, getIpmiUsersCount).WillByDefault(testing::Return(0));
 
         ON_CALL(*this, executeUserRename).WillByDefault(testing::Return());
@@ -289,6 +292,8 @@ class UserMgrInTest : public testing::Test, public UserMgr
                 (override));
 
     MOCK_METHOD(void, executeUserDelete, (const char*), (override));
+
+    MOCK_METHOD(void, executeUserClearFailRecords, (const char*), (override));
 
     MOCK_METHOD(size_t, getIpmiUsersCount, (), (override));
 
@@ -443,6 +448,23 @@ TEST_F(UserMgrInTest, DeleteUserThrowsInternalFailureWhenExecuteUserDeleteFails)
     EXPECT_NO_THROW(
         UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
     EXPECT_CALL(*this, executeUserDelete(testing::StrEq(username)))
+        .WillOnce(testing::Throw(
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()))
+        .WillOnce(testing::DoDefault());
+
+    EXPECT_THROW(
+        deleteUser(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_NO_THROW(UserMgr::deleteUser(username));
+}
+
+TEST_F(UserMgrInTest,
+       DeleteUserThrowsInternalFailureWhenExecuteUserClearFailRecords)
+{
+    const char* username = "user";
+    EXPECT_NO_THROW(
+        UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
+    EXPECT_CALL(*this, executeUserClearFailRecords(testing::StrEq(username)))
         .WillOnce(testing::Throw(
             sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()))
         .WillOnce(testing::DoDefault());

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -386,6 +386,9 @@ void UserMgr::deleteUser(std::string userName)
     try
     {
         executeUserDelete(userName.c_str());
+
+        // Clear user fail records
+        executeUserClearFailRecords(userName.c_str());
     }
     catch (const InternalFailure& e)
     {
@@ -801,12 +804,12 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
     // All user management lock has to be based on /etc/shadow
     // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     // Note: Allowed to unlock password of users with restricted role
+    std::vector<std::string> output;
     if (value == true)
     {
         return userLockedForFailedAttempt(userName);
     }
 
-    std::vector<std::string> output;
     output =
         executeCmd("/usr/sbin/faillock", "--user", userName.c_str(), "--reset");
 
@@ -1435,6 +1438,11 @@ void UserMgr::executeUserAdd(const char* userName, const char* groups,
 void UserMgr::executeUserDelete(const char* userName)
 {
     executeCmd("/usr/sbin/userdel", userName, "-r");
+}
+
+void UserMgr::executeUserClearFailRecords(const char* userName)
+{
+    executeCmd("/usr/sbin/faillock", "--user", userName, "--reset");
 }
 
 void UserMgr::executeUserRename(const char* userName, const char* newUserName)

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -313,6 +313,13 @@ class UserMgr : public Ifaces
 
     virtual void executeUserDelete(const char* userName);
 
+    /** @brief clear user's failure records
+     *  method to clear user fail records and throw if failed.
+     *
+     *  @param[in] userName - name of the user
+     */
+    virtual void executeUserClearFailRecords(const char* userName);
+
     virtual void executeUserRename(const char* userName,
                                    const char* newUserName);
 


### PR DESCRIPTION
Added fix for #phosphor-user-manager/issues/4

If a user account locked due to user's password with too many failed attempts use case, password will locked out for same name account creation. This issues is due to missing authentication failure record files clear in the account user delete path.

Added function for deleting authentication failure record files in the account delete api to fix this issue.

faillock command --reset option is used to clear user's failure records. Refer https://linux.die.net/man/8/faillock for details.

Tested: Created user and perform multiple failed authentication to lock the account. After Account delete, and recreate a user with same name , worked as expected.

Gerrit Review : https://gerrit.openbmc.org/c/openbmc/phosphor-user-manager/+/65302