### PR TITLE
user-delete: swap delete and faillock clear

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 ## To Build
+
 ```
 To build this package, do the following steps:
 
@@ -17,10 +18,14 @@ To clean the repository run `./bootstrap.sh clean`.
 curl -c cjar -b cjar -k -H "Content-Type: application/json" -X POST -d '{"data":[false,"ldap://<ldap://<LDAP server ip/hostname>/", "<bindDN>", "<baseDN>","<bindDNPassword>","<searchScope>","<serverType>"]}''  https://$BMC_IP/xyz/openbmc_project/user/ldap/action/CreateConfig
 
 ```
+
 #### NOTE
-If the configured ldap server is secure then we need to upload the client certificate and the CA certificate in following cases.
- - First time LDAP configuration.
- - Change the already configured Client/CA certificate
+
+If the configured ldap server is secure then we need to upload the client
+certificate and the CA certificate in following cases.
+
+- First time LDAP configuration.
+- Change the already configured Client/CA certificate
 
 #### Upload LDAP Client Certificate
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('phosphor-user-manager',
         'cpp',
-        version: '0.1', meson_version: '>=0.57.0',
+        version: '0.1', meson_version: '>=1.1.1',
         default_options: [
           'warning_level=3',
           'werror=true',

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -795,7 +795,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
     {
         return true; // User account password is locked
     }
-    return false; // User account password is un-locked
+    return false;    // User account password is un-locked
 }
 
 bool UserMgr::userLockedForFailedAttempt(const std::string& userName,

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -385,10 +385,10 @@ void UserMgr::deleteUser(std::string userName)
     throwForRestrictedUserPrivilegeRole(userName);
     try
     {
-        executeUserDelete(userName.c_str());
-
         // Clear user fail records
         executeUserClearFailRecords(userName.c_str());
+
+        executeUserDelete(userName.c_str());
     }
     catch (const InternalFailure& e)
     {


### PR DESCRIPTION
The latest faillock won't accept clearing for a user that does not exist, so we need to swap the order to clear the faillock values before deleting the user.


Change-Id: I175d82a5a5d30048aab4056acf080f3f2fe74d78