### PR TITLE
user-delete: swap delete and faillock clear

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -385,10 +385,10 @@ void UserMgr::deleteUser(std::string userName)
     throwForRestrictedUserPrivilegeRole(userName);
     try
     {
-        executeUserDelete(userName.c_str());
-
         // Clear user fail records
         executeUserClearFailRecords(userName.c_str());
+
+        executeUserDelete(userName.c_str());
     }
     catch (const InternalFailure& e)
     {


### PR DESCRIPTION
The latest faillock won't accept clearing for a user that does not exist, so we need to swap the order to clear the faillock values before deleting the user.


Change-Id: I175d82a5a5d30048aab4056acf080f3f2fe74d78