### PR TITLE
Fixed Internal service error while creating new user when LDAP user is not reachable

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -36,6 +36,7 @@ owners:
 - richard.marian.thomaiyar@linux.intel.com
 
 reviewers:
+- nanzhoumails@gmail.com
 
 matchers:
 

--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -197,8 +197,8 @@ void Config::writeConfig()
     confData << "uid root\n";
     confData << "gid root\n\n";
     confData << "ldap_version 3\n\n";
-    confData << "timelimit 30\n";
-    confData << "bind_timelimit 30\n";
+    confData << "timelimit 5\n";
+    confData << "bind_timelimit 5\n";
     confData << "pagesize 1000\n";
     confData << "referrals off\n\n";
     confData << "uri " << ldapServerURI() << "\n\n";

--- a/phosphor-ldap-config/ldap_config.hpp
+++ b/phosphor-ldap-config/ldap_config.hpp
@@ -277,7 +277,6 @@ class Config : public Ifaces
         "priv-admin",
         "priv-operator",
         "priv-user",
-        "priv-noaccess",
     };
 
     /** @brief React to InterfaceAdded signal

--- a/test/mock_user_mgr.hpp
+++ b/test/mock_user_mgr.hpp
@@ -15,10 +15,13 @@ class MockManager : public UserMgr
     MockManager(sdbusplus::bus_t& bus, const char* path) : UserMgr(bus, path)
     {}
 
-    MOCK_METHOD1(getLdapGroupName, std::string(const std::string& userName));
     MOCK_METHOD0(getPrivilegeMapperObject, DbusUserObj());
     MOCK_METHOD1(userLockedForFailedAttempt, bool(const std::string& userName));
     MOCK_METHOD1(userPasswordExpired, bool(const std::string& userName));
+    MOCK_CONST_METHOD1(getPrimaryGroup, gid_t(const std::string& userName));
+    MOCK_CONST_METHOD3(isGroupMember,
+                       bool(const std::string& userName, gid_t primaryGid,
+                            const std::string& groupName));
 
     friend class TestUserMgr;
 };

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -552,5 +552,43 @@ TEST_F(UserMgrInTest,
     EXPECT_NO_THROW(UserMgr::deleteUser(username));
 }
 
+TEST_F(UserMgrInTest, MinPasswordLengthReturnsIfValueIsTheSame)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+    UserMgr::minPasswordLength(8);
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+}
+
+TEST_F(UserMgrInTest,
+       MinPasswordLengthRejectsTooShortPasswordWithInvalidArgument)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+    EXPECT_THROW(
+        UserMgr::minPasswordLength(minPasswdLength - 1),
+        sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument);
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+}
+
+TEST_F(UserMgrInTest, MinPasswordLengthOnSuccess)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+    UserMgr::minPasswordLength(16);
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 16);
+}
+
+TEST_F(UserMgrInTest, MinPasswordLengthOnFailure)
+{
+    EXPECT_NO_THROW(dumpStringToFile("whatever", tempPamConfigFile));
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+    EXPECT_THROW(
+        UserMgr::minPasswordLength(16),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
+}
+
 } // namespace user
 } // namespace phosphor

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -290,6 +290,9 @@ class UserMgrInTest : public testing::Test, public UserMgr
     MOCK_METHOD(void, executeUserModifyUserEnable, (const char*, bool),
                 (override));
 
+    MOCK_METHOD(std::vector<std::string>, getFailedAttempt, (const char*),
+                (override));
+
   protected:
     static sdbusplus::bus_t busInTest;
     std::string tempPamConfigFile;
@@ -714,6 +717,101 @@ TEST_F(UserMgrInTest, UserEnableThrowsInternalFailureIfExecuteUserModifyFail)
     EXPECT_EQ(std::get<UserEnabled>(userInfo["UserEnabled"]), true);
 
     EXPECT_NO_THROW(UserMgr::deleteUser(username));
+}
+
+TEST_F(
+    UserMgrInTest,
+    UserLockedForFailedAttemptReturnsFalseIfMaxLoginAttemptBeforeLockoutIsZero)
+{
+    EXPECT_FALSE(userLockedForFailedAttempt("whatever"));
+}
+
+TEST_F(UserMgrInTest, UserLockedForFailedAttemptZeroFailuresReturnsFalse)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+    // Example output from BMC
+    // root@s7106:~# pam_tally2 -u root
+    // Login           Failures Latest failure     From
+    // root                0
+    std::vector<std::string> output = {"whatever", "root\t0"};
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Return(output));
+
+    EXPECT_FALSE(userLockedForFailedAttempt(username));
+}
+
+TEST_F(UserMgrInTest, UserLockedForFailedAttemptFailIfGetFailedAttemptFail)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Throw(
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()));
+
+    EXPECT_THROW(
+        userLockedForFailedAttempt(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+}
+
+TEST_F(UserMgrInTest,
+       UserLockedForFailedAttemptThrowsInternalFailureIfFailAttemptsOutOfRange)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+    std::vector<std::string> output = {"whatever", "root\t1000000"};
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Return(output));
+
+    EXPECT_THROW(
+        userLockedForFailedAttempt(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+}
+
+TEST_F(UserMgrInTest,
+       UserLockedForFailedAttemptThrowsInternalFailureIfNoFailDateTime)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+    std::vector<std::string> output = {"whatever", "root\t2"};
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Return(output));
+
+    EXPECT_THROW(
+        userLockedForFailedAttempt(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+}
+
+TEST_F(UserMgrInTest,
+       UserLockedForFailedAttemptThrowsInternalFailureIfWrongDateFormat)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+
+    // Choose a date in the past.
+    std::vector<std::string> output = {"whatever",
+                                       "root\t2\t10/24/2002\t00:00:00"};
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Return(output));
+
+    EXPECT_THROW(
+        userLockedForFailedAttempt(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+}
+
+TEST_F(UserMgrInTest,
+       UserLockedForFailedAttemptReturnsFalseIfLastFailTimeHasTimedOut)
+{
+    std::string username = "user001";
+    initializeAccountPolicy();
+
+    // Choose a date in the past.
+    std::vector<std::string> output = {"whatever",
+                                       "root\t2\t10/24/02\t00:00:00"};
+    EXPECT_CALL(*this, getFailedAttempt(testing::StrEq(username.c_str())))
+        .WillOnce(testing::Return(output));
+
+    EXPECT_EQ(userLockedForFailedAttempt(username), false);
 }
 
 } // namespace user

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -209,7 +209,7 @@ inline constexpr const char* rawConfig = R"(
 # See the pam_unix manpage for other options.
 
 # here are the per-package modules (the "Primary" block)
-password	[success=ok default=die]	pam_tally2.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 #some comments
+password	[success=ok default=die]	pam_tally2.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 deny=2 #some comments
 password	[success=ok default=die]	pam_cracklib.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 #some comments
 password	[success=ok default=die]	pam_ipmicheck.so spec_grp_name=ipmi use_authtok
 password	[success=ok ignore=ignore default=die]	pam_pwhistory.so debug enforce_for_root remember=0 use_authtok
@@ -615,6 +615,32 @@ TEST_F(UserMgrInTest, RememberOldPasswordTimesOnFailure)
     EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
     EXPECT_THROW(
         UserMgr::rememberOldPasswordTimes(16),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+}
+
+TEST_F(UserMgrInTest, MaxLoginAttemptBeforeLockoutReturnsIfValueIsTheSame)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::maxLoginAttemptBeforeLockout(), 2);
+    UserMgr::maxLoginAttemptBeforeLockout(2);
+    EXPECT_EQ(AccountPolicyIface::maxLoginAttemptBeforeLockout(), 2);
+}
+
+TEST_F(UserMgrInTest, MaxLoginAttemptBeforeLockoutOnSuccess)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::maxLoginAttemptBeforeLockout(), 2);
+    UserMgr::maxLoginAttemptBeforeLockout(16);
+    EXPECT_EQ(AccountPolicyIface::maxLoginAttemptBeforeLockout(), 16);
+}
+
+TEST_F(UserMgrInTest, MaxLoginAttemptBeforeLockoutOnFailure)
+{
+    EXPECT_NO_THROW(dumpStringToFile("whatever", tempPamConfigFile));
+    initializeAccountPolicy();
+    EXPECT_THROW(
+        UserMgr::maxLoginAttemptBeforeLockout(16),
         sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
     EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
 }

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -590,5 +590,34 @@ TEST_F(UserMgrInTest, MinPasswordLengthOnFailure)
     EXPECT_EQ(AccountPolicyIface::minPasswordLength(), 8);
 }
 
+TEST_F(UserMgrInTest, RememberOldPasswordTimesReturnsIfValueIsTheSame)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+    UserMgr::rememberOldPasswordTimes(8);
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 8);
+    UserMgr::rememberOldPasswordTimes(8);
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 8);
+}
+
+TEST_F(UserMgrInTest, RememberOldPasswordTimesOnSuccess)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+    UserMgr::rememberOldPasswordTimes(16);
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 16);
+}
+
+TEST_F(UserMgrInTest, RememberOldPasswordTimesOnFailure)
+{
+    EXPECT_NO_THROW(dumpStringToFile("whatever", tempPamConfigFile));
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+    EXPECT_THROW(
+        UserMgr::rememberOldPasswordTimes(16),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+}
+
 } // namespace user
 } // namespace phosphor

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -454,7 +454,6 @@ TEST_F(UserMgrInTest, ThrowForInvalidPrivilegeNoThrowWhenPrivilegeIsValid)
     EXPECT_NO_THROW(throwForInvalidPrivilege("priv-admin"));
     EXPECT_NO_THROW(throwForInvalidPrivilege("priv-operator"));
     EXPECT_NO_THROW(throwForInvalidPrivilege("priv-user"));
-    EXPECT_NO_THROW(throwForInvalidPrivilege("priv-noaccess"));
 }
 
 TEST_F(UserMgrInTest, ThrowForInvalidGroupsThrowsWhenGroupIsInvalid)

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -264,6 +264,9 @@ class UserMgrInTest : public testing::Test, public UserMgr
 
         ON_CALL(*this, executeUserModify(testing::_, testing::_, testing::_))
             .WillByDefault(testing::Return());
+
+        ON_CALL(*this, executeUserModifyUserEnable)
+            .WillByDefault(testing::Return());
     }
 
     ~UserMgrInTest() override
@@ -282,6 +285,9 @@ class UserMgrInTest : public testing::Test, public UserMgr
                 (override));
 
     MOCK_METHOD(void, executeUserModify, (const char*, const char*, bool),
+                (override));
+
+    MOCK_METHOD(void, executeUserModifyUserEnable, (const char*, bool),
                 (override));
 
   protected:
@@ -669,6 +675,45 @@ TEST_F(UserMgrInTest, AccountUnlockTimeoutOnFailure)
         UserMgr::accountUnlockTimeout(16),
         sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
     EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 3);
+}
+
+TEST_F(UserMgrInTest, UserEnableOnSuccess)
+{
+    std::string username = "user001";
+    EXPECT_NO_THROW(
+        UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
+    UserInfoMap userInfo = getUserInfo(username);
+    EXPECT_EQ(std::get<UserEnabled>(userInfo["UserEnabled"]), true);
+
+    EXPECT_NO_THROW(userEnable(username, false));
+
+    userInfo = getUserInfo(username);
+    EXPECT_EQ(std::get<UserEnabled>(userInfo["UserEnabled"]), false);
+
+    EXPECT_NO_THROW(UserMgr::deleteUser(username));
+}
+
+TEST_F(UserMgrInTest, UserEnableThrowsInternalFailureIfExecuteUserModifyFail)
+{
+    std::string username = "user001";
+    EXPECT_NO_THROW(
+        UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
+    UserInfoMap userInfo = getUserInfo(username);
+    EXPECT_EQ(std::get<UserEnabled>(userInfo["UserEnabled"]), true);
+
+    EXPECT_CALL(*this, executeUserModifyUserEnable(testing::StrEq(username),
+                                                   testing::Eq(false)))
+        .WillOnce(testing::Throw(
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()));
+    EXPECT_THROW(
+        userEnable(username, false),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+
+    userInfo = getUserInfo(username);
+    // Stay unchanged
+    EXPECT_EQ(std::get<UserEnabled>(userInfo["UserEnabled"]), true);
+
+    EXPECT_NO_THROW(UserMgr::deleteUser(username));
 }
 
 } // namespace user

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -209,7 +209,7 @@ inline constexpr const char* rawConfig = R"(
 # See the pam_unix manpage for other options.
 
 # here are the per-package modules (the "Primary" block)
-password	[success=ok default=die]	pam_tally2.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 deny=2 #some comments
+password	[success=ok default=die]	pam_tally2.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 deny=2 unlock_time=3 #some comments
 password	[success=ok default=die]	pam_cracklib.so debug enforce_for_root reject_username minlen=8 difok=0 lcredit=0 ocredit=0 dcredit=0 ucredit=0 #some comments
 password	[success=ok default=die]	pam_ipmicheck.so spec_grp_name=ipmi use_authtok
 password	[success=ok ignore=ignore default=die]	pam_pwhistory.so debug enforce_for_root remember=0 use_authtok
@@ -643,6 +643,32 @@ TEST_F(UserMgrInTest, MaxLoginAttemptBeforeLockoutOnFailure)
         UserMgr::maxLoginAttemptBeforeLockout(16),
         sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
     EXPECT_EQ(AccountPolicyIface::rememberOldPasswordTimes(), 0);
+}
+
+TEST_F(UserMgrInTest, AccountUnlockTimeoutReturnsIfValueIsTheSame)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 3);
+    UserMgr::accountUnlockTimeout(3);
+    EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 3);
+}
+
+TEST_F(UserMgrInTest, AccountUnlockTimeoutOnSuccess)
+{
+    initializeAccountPolicy();
+    EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 3);
+    UserMgr::accountUnlockTimeout(16);
+    EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 16);
+}
+
+TEST_F(UserMgrInTest, AccountUnlockTimeoutOnFailure)
+{
+    initializeAccountPolicy();
+    EXPECT_NO_THROW(dumpStringToFile("whatever", tempPamConfigFile));
+    EXPECT_THROW(
+        UserMgr::accountUnlockTimeout(16),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_EQ(AccountPolicyIface::accountUnlockTimeout(), 3);
 }
 
 } // namespace user

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -17,9 +17,12 @@ namespace user
 {
 
 using ::testing::Return;
+using ::testing::Throw;
 
 using InternalFailure =
     sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+using UserNameDoesNotExist =
+    sdbusplus::xyz::openbmc_project::User::Common::Error::UserNameDoesNotExist;
 
 class TestUserMgr : public testing::Test
 {
@@ -91,9 +94,10 @@ TEST_F(TestUserMgr, ldapEntryDoesNotExist)
     std::string userName = "user";
     UserInfoMap userInfo;
 
-    EXPECT_CALL(mockManager, getLdapGroupName(userName))
-        .WillRepeatedly(Return(""));
-    EXPECT_THROW(userInfo = mockManager.getUserInfo(userName), InternalFailure);
+    EXPECT_CALL(mockManager, getPrimaryGroup(userName))
+        .WillRepeatedly(Throw(UserNameDoesNotExist()));
+    EXPECT_THROW(userInfo = mockManager.getUserInfo(userName),
+                 UserNameDoesNotExist);
 }
 
 TEST_F(TestUserMgr, localUser)
@@ -121,13 +125,16 @@ TEST_F(TestUserMgr, ldapUserWithPrivMapper)
     UserInfoMap userInfo;
     std::string userName = "ldapUser";
     std::string ldapGroup = "ldapGroup";
+    gid_t primaryGid = 1000;
 
-    EXPECT_CALL(mockManager, getLdapGroupName(userName))
-        .WillRepeatedly(Return(ldapGroup));
+    EXPECT_CALL(mockManager, getPrimaryGroup(userName))
+        .WillRepeatedly(Return(primaryGid));
     // Create privilege mapper dbus object
     DbusUserObj object = createPrivilegeMapperDbusObject();
     EXPECT_CALL(mockManager, getPrivilegeMapperObject())
         .WillRepeatedly(Return(object));
+    EXPECT_CALL(mockManager, isGroupMember(userName, primaryGid, ldapGroup))
+        .WillRepeatedly(Return(true));
     userInfo = mockManager.getUserInfo(userName);
     EXPECT_EQ(true, std::get<bool>(userInfo["RemoteUser"]));
     EXPECT_EQ("priv-admin", std::get<std::string>(userInfo["UserPrivilege"]));
@@ -135,16 +142,20 @@ TEST_F(TestUserMgr, ldapUserWithPrivMapper)
 
 TEST_F(TestUserMgr, ldapUserWithoutPrivMapper)
 {
+    using ::testing::_;
+
     UserInfoMap userInfo;
     std::string userName = "ldapUser";
     std::string ldapGroup = "ldapGroup";
+    gid_t primaryGid = 1000;
 
-    EXPECT_CALL(mockManager, getLdapGroupName(userName))
-        .WillRepeatedly(Return(ldapGroup));
+    EXPECT_CALL(mockManager, getPrimaryGroup(userName))
+        .WillRepeatedly(Return(primaryGid));
     // Create LDAP config object without privilege mapper
     DbusUserObj object = createLdapConfigObjectWithoutPrivilegeMapper();
     EXPECT_CALL(mockManager, getPrivilegeMapperObject())
         .WillRepeatedly(Return(object));
+    EXPECT_CALL(mockManager, isGroupMember(_, _, _)).Times(0);
     userInfo = mockManager.getUserInfo(userName);
     EXPECT_EQ(true, std::get<bool>(userInfo["RemoteUser"]));
     EXPECT_EQ("", std::get<std::string>(userInfo["UserPrivilege"]));

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -269,6 +269,9 @@ class UserMgrInTest : public testing::Test, public UserMgr
 
         ON_CALL(*this, executeUserDelete).WillByDefault(testing::Return());
 
+        ON_CALL(*this, executeUserClearFailRecords)
+            .WillByDefault(testing::Return());
+
         ON_CALL(*this, getIpmiUsersCount).WillByDefault(testing::Return(0));
 
         ON_CALL(*this, executeUserRename).WillByDefault(testing::Return());
@@ -289,6 +292,8 @@ class UserMgrInTest : public testing::Test, public UserMgr
                 (override));
 
     MOCK_METHOD(void, executeUserDelete, (const char*), (override));
+
+    MOCK_METHOD(void, executeUserClearFailRecords, (const char*), (override));
 
     MOCK_METHOD(size_t, getIpmiUsersCount, (), (override));
 
@@ -443,6 +448,23 @@ TEST_F(UserMgrInTest, DeleteUserThrowsInternalFailureWhenExecuteUserDeleteFails)
     EXPECT_NO_THROW(
         UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
     EXPECT_CALL(*this, executeUserDelete(testing::StrEq(username)))
+        .WillOnce(testing::Throw(
+            sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()))
+        .WillOnce(testing::DoDefault());
+
+    EXPECT_THROW(
+        deleteUser(username),
+        sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure);
+    EXPECT_NO_THROW(UserMgr::deleteUser(username));
+}
+
+TEST_F(UserMgrInTest,
+       DeleteUserThrowsInternalFailureWhenExecuteUserClearFailRecords)
+{
+    const char* username = "user";
+    EXPECT_NO_THROW(
+        UserMgr::createUser(username, {"redfish", "ssh"}, "priv-user", true));
+    EXPECT_CALL(*this, executeUserClearFailRecords(testing::StrEq(username)))
         .WillOnce(testing::Throw(
             sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure()))
         .WillOnce(testing::DoDefault());

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -656,7 +656,7 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName)
     std::vector<std::string> output;
     try
     {
-        output = executeCmd("/usr/sbin/pam_tally2", "-u", userName.c_str());
+        output = getFailedAttempt(userName.c_str());
     }
     catch (const InternalFailure& e)
     {
@@ -1350,6 +1350,11 @@ void UserMgr::executeUserModifyUserEnable(const char* userName, bool enabled)
     // 1970-01-01, that's an implementation-defined behavior
     executeCmd("/usr/sbin/usermod", userName, "-e",
                (enabled ? "" : "1970-01-01"));
+}
+
+std::vector<std::string> UserMgr::getFailedAttempt(const char* userName)
+{
+    return executeCmd("/usr/sbin/pam_tally2", "-u", userName);
 }
 
 } // namespace user

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -617,10 +617,7 @@ void UserMgr::userEnable(const std::string& userName, bool enabled)
     throwForUserDoesNotExist(userName);
     try
     {
-        // set EXPIRE_DATE to 0 to disable user, PAM takes 0 as expire on
-        // 1970-01-01, that's an implementation-defined behavior
-        executeCmd("/usr/sbin/usermod", userName.c_str(), "-e",
-                   (enabled ? "" : "1970-01-01"));
+        executeUserModifyUserEnable(userName.c_str(), enabled);
     }
     catch (const InternalFailure& e)
     {
@@ -631,6 +628,7 @@ void UserMgr::userEnable(const std::string& userName, bool enabled)
     log<level::INFO>("User enabled/disabled state updated successfully",
                      entry("USER_NAME=%s", userName.c_str()),
                      entry("ENABLED=%d", enabled));
+    usersList[userName]->setUserEnabled(enabled);
     return;
 }
 
@@ -1344,6 +1342,14 @@ void UserMgr::executeUserModify(const char* userName, const char* newGroups,
 {
     executeCmd("/usr/sbin/usermod", userName, "-G", newGroups, "-s",
                (sshRequested ? "/bin/sh" : "/bin/nologin"));
+}
+
+void UserMgr::executeUserModifyUserEnable(const char* userName, bool enabled)
+{
+    // set EXPIRE_DATE to 0 to disable user, PAM takes 0 as expire on
+    // 1970-01-01, that's an implementation-defined behavior
+    executeCmd("/usr/sbin/usermod", userName, "-e",
+               (enabled ? "" : "1970-01-01"));
 }
 
 } // namespace user

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1357,5 +1357,17 @@ std::vector<std::string> UserMgr::getFailedAttempt(const char* userName)
     return executeCmd("/usr/sbin/pam_tally2", "-u", userName);
 }
 
+void UserMgr::createGroup(std::string /*groupName*/)
+{
+    log<level::ERR>("Not implemented yet");
+    elog<InternalFailure>();
+}
+
+void UserMgr::deleteGroup(std::string /*groupName*/)
+{
+    log<level::ERR>("Not implemented yet");
+    elog<InternalFailure>();
+}
+
 } // namespace user
 } // namespace phosphor

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1320,7 +1320,7 @@ void UserMgr::executeUserAdd(const char* userName, const char* groups,
     // set EXPIRE_DATE to 0 to disable user, PAM takes 0 as expire on
     // 1970-01-01, that's an implementation-defined behavior
     executeCmd("/usr/sbin/useradd", userName, "-G", groups, "-m", "-N", "-s",
-               (sshRequested ? "/bin/sh" : "/bin/nologin"), "-e",
+               (sshRequested ? "/bin/sh" : "/sbin/nologin"), "-e",
                (enabled ? "" : "1970-01-01"));
 }
 
@@ -1341,7 +1341,7 @@ void UserMgr::executeUserModify(const char* userName, const char* newGroups,
                                 bool sshRequested)
 {
     executeCmd("/usr/sbin/usermod", userName, "-G", newGroups, "-s",
-               (sshRequested ? "/bin/sh" : "/bin/nologin"));
+               (sshRequested ? "/bin/sh" : "/sbin/nologin"));
 }
 
 void UserMgr::executeUserModifyUserEnable(const char* userName, bool enabled)

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -935,53 +935,6 @@ DbusUserObj UserMgr::getPrivilegeMapperObject(void)
     return objects;
 }
 
-std::string UserMgr::getLdapGroupName(const std::string& userName)
-{
-    struct passwd pwd
-    {};
-    struct passwd* pwdPtr = nullptr;
-    auto buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
-    if (buflen < -1)
-    {
-        // Use a default size if there is no hard limit suggested by sysconf()
-        buflen = 1024;
-    }
-    std::vector<char> buffer(buflen);
-    gid_t gid = 0;
-
-    auto status =
-        getpwnam_r(userName.c_str(), &pwd, buffer.data(), buflen, &pwdPtr);
-    // On success, getpwnam_r() returns zero, and set *pwdPtr to pwd.
-    // If no matching password record was found, these functions return 0
-    // and store NULL in *pwdPtr
-    if (!status && (&pwd == pwdPtr))
-    {
-        gid = pwd.pw_gid;
-    }
-    else
-    {
-        log<level::ERR>("User does not exist",
-                        entry("USER_NAME=%s", userName.c_str()));
-        elog<UserNameDoesNotExist>();
-    }
-
-    struct group* groups = nullptr;
-    std::string ldapGroupName;
-
-    while ((groups = getgrent()) != NULL)
-    {
-        if (groups->gr_gid == gid)
-        {
-            ldapGroupName = groups->gr_name;
-            break;
-        }
-    }
-    // Call endgrent() to close the group database.
-    endgrent();
-
-    return ldapGroupName;
-}
-
 std::string UserMgr::getServiceName(std::string&& path, std::string&& intf)
 {
     auto mapperCall = bus.new_method_call(objMapperService, objMapperPath,
@@ -1010,6 +963,99 @@ std::string UserMgr::getServiceName(std::string&& path, std::string&& intf)
     return mapperResponse.begin()->first;
 }
 
+gid_t UserMgr::getPrimaryGroup(const std::string& userName) const
+{
+    static auto buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (buflen <= 0)
+    {
+        // Use a default size if there is no hard limit suggested by sysconf()
+        buflen = 1024;
+    }
+
+    struct passwd pwd;
+    struct passwd* pwdPtr = nullptr;
+    std::vector<char> buffer(buflen);
+
+    auto status = getpwnam_r(userName.c_str(), &pwd, buffer.data(),
+                             buffer.size(), &pwdPtr);
+    // On success, getpwnam_r() returns zero, and set *pwdPtr to pwd.
+    // If no matching password record was found, these functions return 0
+    // and store NULL in *pwdPtr
+    if (!status && (&pwd == pwdPtr))
+    {
+        return pwd.pw_gid;
+    }
+
+    log<level::ERR>("User noes not exist",
+                    entry("USER_NAME=%s", userName.c_str()));
+    elog<UserNameDoesNotExist>();
+}
+
+bool UserMgr::isGroupMember(const std::string& userName, gid_t primaryGid,
+                            const std::string& groupName) const
+{
+    static auto buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
+    if (buflen <= 0)
+    {
+        // Use a default size if there is no hard limit suggested by sysconf()
+        buflen = 1024;
+    }
+
+    struct group grp;
+    struct group* grpPtr = nullptr;
+    std::vector<char> buffer(buflen);
+
+    auto status = getgrnam_r(groupName.c_str(), &grp, buffer.data(),
+                             buffer.size(), &grpPtr);
+
+    // Groups with a lot of members may require a buffer of bigger size than
+    // suggested by _SC_GETGR_R_SIZE_MAX.
+    // 32K should be enough for about 2K members.
+    constexpr auto maxBufferLength = 32 * 1024;
+    while (status == ERANGE && buflen < maxBufferLength)
+    {
+        buflen *= 2;
+        buffer.resize(buflen);
+
+        log<level::DEBUG>("Increase buffer for getgrnam_r()",
+                          entry("BUFFER_LENGTH=%zu", buflen));
+
+        status = getgrnam_r(groupName.c_str(), &grp, buffer.data(),
+                            buffer.size(), &grpPtr);
+    }
+
+    // On success, getgrnam_r() returns zero, and set *grpPtr to grp.
+    // If no matching group record was found, these functions return 0
+    // and store NULL in *grpPtr
+    if (!status && (&grp == grpPtr))
+    {
+        if (primaryGid == grp.gr_gid)
+        {
+            return true;
+        }
+
+        for (auto i = 0; grp.gr_mem && grp.gr_mem[i]; ++i)
+        {
+            if (userName == grp.gr_mem[i])
+            {
+                return true;
+            }
+        }
+    }
+    else if (status == ERANGE)
+    {
+        log<level::ERR>("Group info requires too much memory",
+                        entry("GROUP_NAME=%s", groupName.c_str()));
+    }
+    else
+    {
+        log<level::ERR>("Group does not exist",
+                        entry("GROUP_NAME=%s", groupName.c_str()));
+    }
+
+    return false;
+}
+
 UserInfoMap UserMgr::getUserInfo(std::string userName)
 {
     UserInfoMap userInfo;
@@ -1028,13 +1074,7 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
     }
     else
     {
-        std::string ldapGroupName = getLdapGroupName(userName);
-        if (ldapGroupName.empty())
-        {
-            log<level::ERR>("Unable to get group name",
-                            entry("USER_NAME=%s", userName.c_str()));
-            elog<InternalFailure>();
-        }
+        auto primaryGid = getPrimaryGroup(userName);
 
         DbusUserObj objects = getPrivilegeMapperObject();
 
@@ -1043,28 +1083,18 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
 
         try
         {
-            for (const auto& obj : objects)
+            for (const auto& [path, interfaces] : objects)
             {
-                for (const auto& interface : obj.second)
+                auto it = interfaces.find("xyz.openbmc_project.Object.Enable");
+                if (it != interfaces.end())
                 {
-                    if ((interface.first ==
-                         "xyz.openbmc_project.Object.Enable"))
+                    auto propIt = it->second.find("Enabled");
+                    if (propIt != it->second.end() &&
+                        std::get<bool>(propIt->second))
                     {
-                        for (const auto& property : interface.second)
-                        {
-                            auto value = std::get<bool>(property.second);
-                            if ((property.first == "Enabled") &&
-                                (value == true))
-                            {
-                                ldapConfigPath = obj.first;
-                                break;
-                            }
-                        }
+                        ldapConfigPath = path.str + '/';
+                        break;
                     }
-                }
-                if (!ldapConfigPath.empty())
-                {
-                    break;
                 }
             }
 
@@ -1073,35 +1103,37 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
                 return userInfo;
             }
 
-            for (const auto& obj : objects)
+            for (const auto& [path, interfaces] : objects)
             {
-                for (const auto& interface : obj.second)
+                if (!path.str.starts_with(ldapConfigPath))
                 {
-                    if ((interface.first ==
-                         "xyz.openbmc_project.User.PrivilegeMapperEntry") &&
-                        (obj.first.str.find(ldapConfigPath) !=
-                         std::string::npos))
-                    {
-                        std::string privilege;
-                        std::string groupName;
+                    continue;
+                }
 
-                        for (const auto& property : interface.second)
+                auto it = interfaces.find(
+                    "xyz.openbmc_project.User.PrivilegeMapperEntry");
+                if (it != interfaces.end())
+                {
+                    std::string privilege;
+                    std::string groupName;
+
+                    for (const auto& [propName, propValue] : it->second)
+                    {
+                        if (propName == "GroupName")
                         {
-                            auto value = std::get<std::string>(property.second);
-                            if (property.first == "GroupName")
-                            {
-                                groupName = value;
-                            }
-                            else if (property.first == "Privilege")
-                            {
-                                privilege = value;
-                            }
+                            groupName = std::get<std::string>(propValue);
                         }
-                        if (groupName == ldapGroupName)
+                        else if (propName == "Privilege")
                         {
-                            userPrivilege = privilege;
-                            break;
+                            privilege = std::get<std::string>(propValue);
                         }
+                    }
+
+                    if (!groupName.empty() && !privilege.empty() &&
+                        isGroupMember(userName, primaryGid, groupName))
+                    {
+                        userPrivilege = privilege;
+                        break;
                     }
                 }
                 if (!userPrivilege.empty())

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -386,6 +386,9 @@ void UserMgr::deleteUser(std::string userName)
     try
     {
         executeUserDelete(userName.c_str());
+
+        // Clear user fail records
+        executeUserClearFailRecords(userName.c_str());
     }
     catch (const InternalFailure& e)
     {
@@ -801,12 +804,12 @@ bool UserMgr::userLockedForFailedAttempt(const std::string& userName,
     // All user management lock has to be based on /etc/shadow
     // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
     // Note: Allowed to unlock password of users with restricted role
+    std::vector<std::string> output;
     if (value == true)
     {
         return userLockedForFailedAttempt(userName);
     }
 
-    std::vector<std::string> output;
     output =
         executeCmd("/usr/sbin/faillock", "--user", userName.c_str(), "--reset");
 
@@ -1435,6 +1438,11 @@ void UserMgr::executeUserAdd(const char* userName, const char* groups,
 void UserMgr::executeUserDelete(const char* userName)
 {
     executeCmd("/usr/sbin/userdel", userName, "-r");
+}
+
+void UserMgr::executeUserClearFailRecords(const char* userName)
+{
+    executeCmd("/usr/sbin/faillock", "--user", userName, "--reset");
 }
 
 void UserMgr::executeUserRename(const char* userName, const char* newUserName)

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -63,8 +63,7 @@ using DbusUserObjPath = sdbusplus::message::object_path;
 
 using DbusUserPropVariant = std::variant<Privilege, ServiceEnabled>;
 
-using DbusUserObjProperties =
-    std::vector<std::pair<PropertyName, DbusUserPropVariant>>;
+using DbusUserObjProperties = std::map<PropertyName, DbusUserPropVariant>;
 
 using Interface = std::string;
 
@@ -403,15 +402,24 @@ class UserMgr : public Ifaces
      */
     std::string getServiceName(std::string&& path, std::string&& intf);
 
-  protected:
-    /** @brief get LDAP group name
-     *  method to get LDAP group name for the given LDAP user
+    /** @brief get primary group ID of specified user
      *
-     *  @param[in] - userName
-     *  @return - group name
+     * @param[in] - userName
+     * @return - primary group ID
      */
-    virtual std::string getLdapGroupName(const std::string& userName);
+    virtual gid_t getPrimaryGroup(const std::string& userName) const;
 
+    /** @brief check whether if the user is a member of the group
+     *
+     * @param[in] - userName
+     * @param[in] - ID of the user's primary group
+     * @param[in] - groupName
+     * @return - true if the user is a member of the group
+     */
+    virtual bool isGroupMember(const std::string& userName, gid_t primaryGid,
+                               const std::string& groupName) const;
+
+  protected:
     /** @brief get privilege mapper object
      *  method to get dbus privilege mapper object
      *

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -323,6 +323,10 @@ class UserMgr : public Ifaces
     virtual void executeUserModifyUserEnable(const char* userName,
                                              bool enabled);
 
+    void createGroup(std::string groupName) override;
+
+    void deleteGroup(std::string groupName) override;
+
     virtual std::vector<std::string> getFailedAttempt(const char* userName);
 
     /** @brief check for valid privielge

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -320,6 +320,9 @@ class UserMgr : public Ifaces
     virtual void executeUserModify(const char* userName, const char* newGroups,
                                    bool sshRequested);
 
+    virtual void executeUserModifyUserEnable(const char* userName,
+                                             bool enabled);
+
     /** @brief check for valid privielge
      *  method to check valid privilege, and throw if invalid
      *

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -323,6 +323,8 @@ class UserMgr : public Ifaces
     virtual void executeUserModifyUserEnable(const char* userName,
                                              bool enabled);
 
+    virtual std::vector<std::string> getFailedAttempt(const char* userName);
+
     /** @brief check for valid privielge
      *  method to check valid privilege, and throw if invalid
      *

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -350,7 +350,7 @@ class UserMgr : public Ifaces
 
     /** @brief privilege manager container */
     std::vector<std::string> privMgr = {"priv-admin", "priv-operator",
-                                        "priv-user", "priv-noaccess"};
+                                        "priv-user"};
 
     /** @brief groups manager container */
     std::vector<std::string> groupsMgr = {"web", "redfish", "ipmi", "ssh"};

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -313,6 +313,13 @@ class UserMgr : public Ifaces
 
     virtual void executeUserDelete(const char* userName);
 
+    /** @brief clear user's failure records
+     *  method to clear user fail records and throw if failed.
+     *
+     *  @param[in] userName - name of the user
+     */
+    virtual void executeUserClearFailRecords(const char* userName);
+
     virtual void executeUserRename(const char* userName,
                                    const char* newUserName);
 

--- a/users.cpp
+++ b/users.cpp
@@ -143,6 +143,11 @@ bool Users::userEnabled(void) const
     return UsersIface::userEnabled();
 }
 
+void Users::setUserEnabled(bool value)
+{
+    UsersIface::userEnabled(value);
+}
+
 /** @brief update user enabled state
  *
  *  @param[in] value - bool value

--- a/users.hpp
+++ b/users.hpp
@@ -97,6 +97,8 @@ class Users : public Interfaces
      */
     bool userEnabled(void) const override;
 
+    void setUserEnabled(bool value);
+
     /** @brief update user enabled state
      *
      *  @param[in] value - bool value


### PR DESCRIPTION
Changed timelimit,bind_timelimit value nslcd.conf

Fix: By lowering the bind_timelimit value from 30 to 5 seconds,
       the system will now attempt to bind to LDAP for 5 seconds instead of 30.
       If LDAP is unreachable, this shorter timeout will allow the system to
       quickly check the local files, ensuring that D-Bus receives a timely
       response indicating success or failure.