### PR TITLE
Changed timelimit,bind_timelimit value in nslcd

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -197,8 +197,8 @@ void Config::writeConfig()
     confData << "uid root\n";
     confData << "gid root\n\n";
     confData << "ldap_version 3\n\n";
-    confData << "timelimit 30\n";
-    confData << "bind_timelimit 30\n";
+    confData << "timelimit 5\n";
+    confData << "bind_timelimit 5\n";
     confData << "pagesize 1000\n";
     confData << "referrals off\n\n";
     confData << "uri " << ldapServerURI() << "\n\n";


### PR DESCRIPTION
This commit fix errors while creating new user when LDAP server is not reachable.

By lowering the bind_timelimit value from 30 to 5 seconds, system will now attempt to bind to LDAP for 5 seconds instead of 30. If LDAP is unreachable, this shorter timeout will allow the system to quickly check the local files, ensuring that D-Bus receives a timely response indicating success or failure.

Tested By:
Created a new user when configured LDAP is not reachable. User created successfully and present in D-bus object.

Change-Id: I31114bbdd69101ab72e19771041d5abc95004cdc