### PR TITLE
MFA feature: Enable google authenticator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,7 +87,7 @@ IndentWidth:     4
 IndentWrappedFunctionNames: true
 InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: OuterScope
+LambdaBodyIndentation: Signature
 LineEnding: LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
@@ -98,13 +98,14 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 25
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 50
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
+PenaltyIndentedWhitespace: 1
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left

--- a/file.hpp
+++ b/file.hpp
@@ -40,9 +40,7 @@ class File
      *  @param[in] removeOnExit - File to be removed at exit or no
      */
     File(const std::string& name, const std::string& mode,
-         bool removeOnExit = false) :
-        name(name),
-        removeOnExit(removeOnExit)
+         bool removeOnExit = false) : name(name), removeOnExit(removeOnExit)
     {
         fp = fopen(name.c_str(), mode.c_str());
     }
@@ -55,9 +53,7 @@ class File
      *  @param[in] removeOnExit - File to be removed at exit or no
      */
     File(int fd, const std::string& name, const std::string& mode,
-         bool removeOnExit = false) :
-        name(name),
-        removeOnExit(removeOnExit)
+         bool removeOnExit = false) : name(name), removeOnExit(removeOnExit)
     {
         fp = fdopen(fd, mode.c_str());
     }

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,8 @@ systemd_dep = dependency('systemd')
 
 cpp = meson.get_compiler('cpp')
 
+boost_dep = dependency('boost')
+
 # Get Cereal dependency.
 cereal_dep = dependency('cereal', required: false)
 has_cereal = cpp.has_header_symbol(
@@ -82,13 +84,16 @@ if not has_cereal
     cereal_dep = cereal_proj.dependency('cereal')
 endif
 
+
 user_manager_src = [
     'mainapp.cpp',
     'user_mgr.cpp',
     'users.cpp'
 ]
-
+pam = cpp.find_library('pam', required: true)
 user_manager_deps = [
+     boost_dep,
+     pam,
      sdbusplus_dep,
      phosphor_logging_dep,
      phosphor_dbus_interfaces_dep
@@ -130,6 +135,10 @@ install_data(
 install_data(
     'nslcd',
     install_dir: get_option('datadir') / 'phosphor-certificate-manager',
+)
+install_data(
+    'mfa_pam',
+    install_dir: '/etc/pam.d/',
 )
 
 # Figure out how to use install_symlink to install symlink to a file of another

--- a/mfa_pam
+++ b/mfa_pam
@@ -1,0 +1,4 @@
+# /etc/pam.d/mfa
+
+# Google Authenticator for two-factor authentication.
+auth       required     pam_google_authenticator.so secret=/home/${USER}/.google_authenticator.tmp

--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -50,18 +50,17 @@ using Key = std::string;
 using Val = std::string;
 using ConfigInfo = std::map<Key, Val>;
 
-Config::Config(sdbusplus::bus_t& bus, const char* path, const char* filePath,
-               const char* caCertFile, const char* certFile, bool secureLDAP,
-               std::string ldapServerURI, std::string ldapBindDN,
-               std::string ldapBaseDN, std::string&& ldapBindDNPassword,
-               ConfigIface::SearchScope ldapSearchScope,
-               ConfigIface::Type ldapType, bool ldapServiceEnabled,
-               std::string userNameAttr, std::string groupNameAttr,
-               ConfigMgr& parent) :
-    Ifaces(bus, path, Ifaces::action::defer_emit),
-    secureLDAP(secureLDAP), ldapBindPassword(std::move(ldapBindDNPassword)),
-    tlsCacertFile(caCertFile), tlsCertFile(certFile), configFilePath(filePath),
-    objectPath(path), bus(bus), parent(parent),
+Config::Config(
+    sdbusplus::bus_t& bus, const char* path, const char* filePath,
+    const char* caCertFile, const char* certFile, bool secureLDAP,
+    std::string ldapServerURI, std::string ldapBindDN, std::string ldapBaseDN,
+    std::string&& ldapBindDNPassword, ConfigIface::SearchScope ldapSearchScope,
+    ConfigIface::Type ldapType, bool ldapServiceEnabled,
+    std::string userNameAttr, std::string groupNameAttr, ConfigMgr& parent) :
+    Ifaces(bus, path, Ifaces::action::defer_emit), secureLDAP(secureLDAP),
+    ldapBindPassword(std::move(ldapBindDNPassword)), tlsCacertFile(caCertFile),
+    tlsCertFile(certFile), configFilePath(filePath), objectPath(path), bus(bus),
+    parent(parent),
     certificateInstalledSignal(
         bus, sdbusplus::bus::match::rules::interfacesAdded(certRootPath),
         std::bind(std::mem_fn(&Config::certificateInstalled), this,
@@ -110,9 +109,9 @@ Config::Config(sdbusplus::bus_t& bus, const char* path, const char* filePath,
 Config::Config(sdbusplus::bus_t& bus, const char* path, const char* filePath,
                const char* caCertFile, const char* certFile,
                ConfigIface::Type ldapType, ConfigMgr& parent) :
-    Ifaces(bus, path, Ifaces::action::defer_emit),
-    secureLDAP(false), tlsCacertFile(caCertFile), tlsCertFile(certFile),
-    configFilePath(filePath), objectPath(path), bus(bus), parent(parent),
+    Ifaces(bus, path, Ifaces::action::defer_emit), secureLDAP(false),
+    tlsCacertFile(caCertFile), tlsCertFile(certFile), configFilePath(filePath),
+    objectPath(path), bus(bus), parent(parent),
     certificateInstalledSignal(
         bus, sdbusplus::bus::match::rules::interfacesAdded(certRootPath),
         std::bind(std::mem_fn(&Config::certificateInstalled), this,

--- a/phosphor-ldap-config/ldap_config_mgr.hpp
+++ b/phosphor-ldap-config/ldap_config_mgr.hpp
@@ -17,10 +17,10 @@ namespace ldap
 
 static constexpr auto defaultNslcdFile = "nslcd.conf.default";
 static constexpr auto nsSwitchFile = "nsswitch.conf";
-static auto openLDAPDbusObjectPath = std::string(LDAP_CONFIG_ROOT) +
-                                     "/openldap";
-static auto adDbusObjectPath = std::string(LDAP_CONFIG_ROOT) +
-                               "/active_directory";
+static auto openLDAPDbusObjectPath =
+    std::string(LDAP_CONFIG_ROOT) + "/openldap";
+static auto adDbusObjectPath =
+    std::string(LDAP_CONFIG_ROOT) + "/active_directory";
 
 using CreateIface = sdbusplus::server::object_t<
     sdbusplus::xyz::openbmc_project::User::Ldap::server::Create>;
@@ -72,13 +72,11 @@ class ConfigMgr : public CreateIface
      *             the username in the LDAP server.
      *  @returns the object path of the D-Bus object created.
      */
-    std::string createConfig(std::string ldapServerURI, std::string ldapBindDN,
-                             std::string ldapBaseDN,
-                             std::string ldapBindDNPassword,
-                             CreateIface::SearchScope ldapSearchScope,
-                             CreateIface::Type ldapType,
-                             std::string groupNameAttribute,
-                             std::string userNameAttribute) override;
+    std::string createConfig(
+        std::string ldapServerURI, std::string ldapBindDN,
+        std::string ldapBaseDN, std::string ldapBindDNPassword,
+        CreateIface::SearchScope ldapSearchScope, CreateIface::Type ldapType,
+        std::string groupNameAttribute, std::string userNameAttribute) override;
 
     /** @brief restarts given service
      *  @param[in] service - Service to be restarted.

--- a/phosphor-ldap-config/main.cpp
+++ b/phosphor-ldap-config/main.cpp
@@ -17,8 +17,8 @@ int main(int /*argc*/, char** /*argv*/)
     std::filesystem::path configDir =
         std::filesystem::path(LDAP_CONFIG_FILE).parent_path();
 
-    if (!std::filesystem::exists(configDir /
-                                 phosphor::ldap::defaultNslcdFile) ||
+    if (!std::filesystem::exists(
+            configDir / phosphor::ldap::defaultNslcdFile) ||
         !std::filesystem::exists(configDir / phosphor::ldap::nsSwitchFile))
     {
         lg2::error("Failed to start phosphor-ldap-manager, configfile(s) are "

--- a/phosphor-ldap-config/utils.cpp
+++ b/phosphor-ldap-config/utils.cpp
@@ -57,8 +57,8 @@ bool isValidLDAPURI(const std::string& uri, const char* scheme)
 
     auto result = getaddrinfo(ludppPtr->lud_host, nullptr, &hints, &servinfo);
     auto cleanupFunc = [](addrinfo* servinfo) { freeaddrinfo(servinfo); };
-    std::unique_ptr<addrinfo, decltype(cleanupFunc)> servinfoPtr(servinfo,
-                                                                 cleanupFunc);
+    std::unique_ptr<addrinfo, decltype(cleanupFunc)> servinfoPtr(
+        servinfo, cleanupFunc);
 
     if (result)
     {

--- a/test/user_mgr_test.cpp
+++ b/test/user_mgr_test.cpp
@@ -236,8 +236,8 @@ void dumpStringToFile(const std::string& str, const std::string& filePath)
 {
     std::ofstream outputFileStream;
 
-    outputFileStream.exceptions(std::ofstream::failbit | std::ofstream::badbit |
-                                std::ofstream::eofbit);
+    outputFileStream.exceptions(
+        std::ofstream::failbit | std::ofstream::badbit | std::ofstream::eofbit);
 
     outputFileStream.open(filePath, std::ios::out);
     outputFileStream << str << "\n" << std::flush;
@@ -274,16 +274,18 @@ class UserMgrInTest : public testing::Test, public UserMgr
         ON_CALL(*this, executeUserAdd(testing::_, testing::_, testing::_,
                                       testing::Eq(true)))
             .WillByDefault([this]() {
-            ON_CALL(*this, isUserEnabled).WillByDefault(testing::Return(true));
-            testing::Return();
-        });
+                ON_CALL(*this, isUserEnabled)
+                    .WillByDefault(testing::Return(true));
+                testing::Return();
+            });
 
         ON_CALL(*this, executeUserAdd(testing::_, testing::_, testing::_,
                                       testing::Eq(false)))
             .WillByDefault([this]() {
-            ON_CALL(*this, isUserEnabled).WillByDefault(testing::Return(false));
-            testing::Return();
-        });
+                ON_CALL(*this, isUserEnabled)
+                    .WillByDefault(testing::Return(false));
+                testing::Return();
+            });
 
         ON_CALL(*this, executeUserDelete).WillByDefault(testing::Return());
 
@@ -300,16 +302,18 @@ class UserMgrInTest : public testing::Test, public UserMgr
         ON_CALL(*this,
                 executeUserModifyUserEnable(testing::_, testing::Eq(true)))
             .WillByDefault([this]() {
-            ON_CALL(*this, isUserEnabled).WillByDefault(testing::Return(true));
-            testing::Return();
-        });
+                ON_CALL(*this, isUserEnabled)
+                    .WillByDefault(testing::Return(true));
+                testing::Return();
+            });
 
         ON_CALL(*this,
                 executeUserModifyUserEnable(testing::_, testing::Eq(false)))
             .WillByDefault([this]() {
-            ON_CALL(*this, isUserEnabled).WillByDefault(testing::Return(false));
-            testing::Return();
-        });
+                ON_CALL(*this, isUserEnabled)
+                    .WillByDefault(testing::Return(false));
+                testing::Return();
+            });
 
         ON_CALL(*this, executeGroupCreation(testing::_))
             .WillByDefault(testing::Return());

--- a/totp.hpp
+++ b/totp.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "config.h"
+
+#include <security/pam_appl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/lg2.hpp>
+
+#include <cstring>
+#include <memory>
+#include <span>
+#include <string_view>
+
+struct PasswordData
+{
+    struct Response
+    {
+        std::string_view prompt;
+        std::string value;
+    };
+
+    std::vector<Response> responseData;
+
+    int addPrompt(std::string_view prompt, std::string_view value)
+    {
+        if (value.size() + 1 > PAM_MAX_MSG_SIZE)
+        {
+            lg2::error("value length error{PROMPT}", "PROMPT", prompt);
+            return PAM_CONV_ERR;
+        }
+        responseData.emplace_back(prompt, std::string(value));
+        return PAM_SUCCESS;
+    }
+
+    int makeResponse(const pam_message& msg, pam_response& response)
+    {
+        switch (msg.msg_style)
+        {
+            case PAM_PROMPT_ECHO_ON:
+                break;
+            case PAM_PROMPT_ECHO_OFF:
+            {
+                std::string prompt(msg.msg);
+                auto iter = std::ranges::find_if(
+                    responseData, [&prompt](const Response& data) {
+                        return prompt.starts_with(data.prompt);
+                    });
+                if (iter == responseData.end())
+                {
+                    return PAM_CONV_ERR;
+                }
+                response.resp = strdup(iter->value.c_str());
+                return PAM_SUCCESS;
+            }
+            break;
+            case PAM_ERROR_MSG:
+            {
+                lg2::error("Pam error {MSG}", "MSG", msg.msg);
+            }
+            break;
+            case PAM_TEXT_INFO:
+            {
+                lg2::error("Pam info {MSG}", "MSG", msg.msg);
+            }
+            break;
+            default:
+            {
+                return PAM_CONV_ERR;
+            }
+        }
+        return PAM_SUCCESS;
+    }
+};
+
+// function used to get user input
+inline int pamFunctionConversation(int numMsg, const struct pam_message** msgs,
+                                   struct pam_response** resp, void* appdataPtr)
+{
+    if ((appdataPtr == nullptr) || (msgs == nullptr) || (resp == nullptr))
+    {
+        return PAM_CONV_ERR;
+    }
+
+    if (numMsg <= 0 || numMsg >= PAM_MAX_NUM_MSG)
+    {
+        return PAM_CONV_ERR;
+    }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    PasswordData* appPass = reinterpret_cast<PasswordData*>(appdataPtr);
+    auto msgCount = static_cast<size_t>(numMsg);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+    auto responseArrPtr = std::make_unique<pam_response[]>(msgCount);
+    auto responses = std::span(responseArrPtr.get(), msgCount);
+    auto messagePtrs = std::span(msgs, msgCount);
+    for (size_t i = 0; i < msgCount; ++i)
+    {
+        const pam_message& msg = *(messagePtrs[i]);
+
+        pam_response& response = responses[i];
+        response.resp_retcode = 0;
+        response.resp = nullptr;
+
+        int r = appPass->makeResponse(msg, response);
+        if (r != PAM_SUCCESS)
+        {
+            return r;
+        }
+    }
+
+    *resp = responseArrPtr.release();
+    return PAM_SUCCESS;
+}
+
+struct Totp
+{
+    /**
+     * @brief Attempt username/password authentication via PAM.
+     * @param username The provided username aka account name.
+     * @param token The provided MFA token.
+     * @returns PAM error code or PAM_SUCCESS for success. */
+    static inline int verify(std::string_view username, std::string token)
+    {
+        std::string userStr(username);
+        PasswordData data;
+
+        if (int ret = data.addPrompt("Verification code: ", token);
+            ret != PAM_SUCCESS)
+        {
+            return ret;
+        }
+
+        const struct pam_conv localConversation = {pamFunctionConversation,
+                                                   &data};
+        pam_handle_t* localAuthHandle = nullptr; // this gets set by pam_start
+
+        int retval = pam_start("mfa_pam", userStr.c_str(), &localConversation,
+                               &localAuthHandle);
+        if (retval != PAM_SUCCESS)
+        {
+            return retval;
+        }
+
+        retval = pam_authenticate(localAuthHandle,
+                                  PAM_SILENT | PAM_DISALLOW_NULL_AUTHTOK);
+        if (retval != PAM_SUCCESS)
+        {
+            pam_end(localAuthHandle, PAM_SUCCESS); // ignore retval
+            return retval;
+        }
+        return pam_end(localAuthHandle, PAM_SUCCESS);
+    }
+};

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -154,10 +154,10 @@ std::string getCSVFromVector(std::span<const std::string> vec)
     }
     return std::accumulate(std::next(vec.begin()), vec.end(), vec[0],
                            [](std::string&& val, std::string_view element) {
-        val += ',';
-        val += element;
-        return val;
-    });
+                               val += ',';
+                               val += element;
+                               return val;
+                           });
 }
 
 bool removeStringFromCSV(std::string& csvStr, const std::string& delStr)
@@ -984,8 +984,8 @@ bool UserMgr::userPasswordExpired(const std::string& userName)
         buflen = 1024;
     }
     std::vector<char> buffer(buflen);
-    auto status = getspnam_r(userName.c_str(), &spwd, buffer.data(), buflen,
-                             &spwdPtr);
+    auto status =
+        getspnam_r(userName.c_str(), &spwd, buffer.data(), buflen, &spwdPtr);
     // On success, getspnam_r() returns zero, and sets *spwdPtr to spwd.
     // If no matching password record was found, these functions return 0
     // and store NULL in *spwdPtr
@@ -1132,8 +1132,8 @@ DbusUserObj UserMgr::getPrivilegeMapperObject(void)
         std::string basePath = "/xyz/openbmc_project/user/ldap/openldap";
         std::string interface = "xyz.openbmc_project.User.Ldap.Config";
 
-        auto ldapMgmtService = getServiceName(std::move(basePath),
-                                              std::move(interface));
+        auto ldapMgmtService =
+            getServiceName(std::move(basePath), std::move(interface));
         auto method = bus.new_method_call(
             ldapMgmtService.c_str(), ldapMgrObjBasePath,
             "org.freedesktop.DBus.ObjectManager", "GetManagedObjects");

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1630,5 +1630,42 @@ std::vector<std::string> UserMgr::getFailedAttempt(const char* userName)
     return executeCmd("/usr/sbin/faillock", "--user", userName);
 }
 
+std::set<MultiFactorAuthType>& allAuthTypes()
+{
+    using namespace sdbusplus::common::xyz::openbmc_project::user::details;
+    static std::set<MultiFactorAuthType> authTypeSet;
+    if (authTypeSet.empty())
+    {
+        for (const auto& item : mappingMultiFactorAuthConfigurationType)
+        {
+            authTypeSet.insert(std::get<1>(item));
+        }
+    }
+    return authTypeSet;
+}
+MultiFactorAuthType UserMgr::enabled(MultiFactorAuthType value, bool skipSignal)
+{
+    switch (value)
+    {
+        case MultiFactorAuthType::None:
+            for (auto type : allAuthTypes())
+            {
+                for (auto& u : usersList)
+                {
+                    u.second->enableMultiFactorAuth(type, false);
+                }
+            }
+            break;
+        case MultiFactorAuthType::GoogleAuthenticator:
+            for (auto& u : usersList)
+            {
+                u.second->enableMultiFactorAuth(
+                    MultiFactorAuthType::GoogleAuthenticator, true);
+            }
+            break;
+    }
+    return MultiFactorAuthConfigurationIface::enabled(value, skipSignal);
+}
+
 } // namespace user
 } // namespace phosphor

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -26,6 +26,7 @@
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/User/AccountPolicy/server.hpp>
 #include <xyz/openbmc_project/User/Manager/server.hpp>
+#include <xyz/openbmc_project/User/MultiFactorAuthConfiguration/server.hpp>
 
 #include <span>
 #include <string>
@@ -50,7 +51,11 @@ using UserSSHLists =
 using AccountPolicyIface =
     sdbusplus::xyz::openbmc_project::User::server::AccountPolicy;
 
-using Ifaces = sdbusplus::server::object_t<UserMgrIface, AccountPolicyIface>;
+using MultiFactorAuthConfigurationIface =
+    sdbusplus::xyz::openbmc_project::User::server::MultiFactorAuthConfiguration;
+
+using Ifaces = sdbusplus::server::object_t<UserMgrIface, AccountPolicyIface,
+                                           MultiFactorAuthConfigurationIface>;
 
 using Privilege = std::string;
 using GroupList = std::vector<std::string>;
@@ -73,6 +78,8 @@ using DbusUserObjValue = std::map<Interface, DbusUserObjProperties>;
 
 using DbusUserObj = std::map<DbusUserObjPath, DbusUserObjValue>;
 
+using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
+    MultiFactorAuthConfiguration::Type;
 std::string getCSVFromVector(std::span<const std::string> vec);
 
 bool removeStringFromCSV(std::string& csvStr, const std::string& delStr);
@@ -259,6 +266,9 @@ class UserMgr : public Ifaces
     void createGroup(std::string groupName) override;
 
     void deleteGroup(std::string groupName) override;
+
+    virtual MultiFactorAuthType enabled(MultiFactorAuthType value,
+                                        bool skipSignal) override;
 
     static std::vector<std::string> readAllGroupsOnSystem();
 

--- a/users.cpp
+++ b/users.cpp
@@ -18,8 +18,10 @@
 
 #include "users.hpp"
 
+#include "totp.hpp"
 #include "user_mgr.hpp"
 
+#include <pwd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -31,7 +33,7 @@
 #include <xyz/openbmc_project/User/Common/error.hpp>
 
 #include <filesystem>
-
+#include <fstream>
 namespace phosphor
 {
 namespace user
@@ -48,6 +50,10 @@ using NoResource =
     sdbusplus::xyz::openbmc_project::User::Common::Error::NoResource;
 
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
+constexpr std::string_view authAppPath = "/usr/bin/google-authenticator";
+constexpr std::string_view secretKeyPath = "/home/{}/.google_authenticator";
+constexpr std::string_view secretKeyTempPath =
+    "/home/{}/.google_authenticator.tmp";
 
 /** @brief Constructs UserMgr object.
  *
@@ -192,6 +198,154 @@ bool Users::userLockedForFailedAttempt(bool value)
 bool Users::userPasswordExpired(void) const
 {
     return manager.userPasswordExpired(userName);
+}
+bool changeFileOwnership(const std::string& filePath,
+                         const std::string& userName)
+{
+    // Get the user ID
+    struct passwd* pwd = getpwnam(userName.c_str());
+    if (pwd == nullptr)
+    {
+        lg2::error("Failed to get user ID for user:{USER}", "USER", userName);
+        return false;
+    }
+    // Change the ownership of the file
+    if (chown(filePath.c_str(), pwd->pw_uid, pwd->pw_gid) != 0)
+    {
+        lg2::error("Ownership change error {PATH}", "PATH", filePath);
+        return false;
+    }
+    return true;
+}
+
+std::string Users::createSecretKey()
+{
+    if (!std::filesystem::exists(authAppPath))
+    {
+        lg2::error("No authenticator app found at {PATH}", "PATH", authAppPath);
+        elog<InternalFailure>();
+        return "";
+    }
+    std::string path = std::format(secretKeyTempPath, userName);
+    /*
+    -u no-rate-limit
+    -W minimal-window
+    -Q qr-mode (NONE, ANSI, UTF8)
+    -t time-based
+    -f force file
+    -D allow-reuse
+    -C no-confirm no confirmation required for code provisioned
+    */
+    executeCmd(authAppPath.data(), "-s", path.c_str(), "-u", "-W", "-Q", "NONE",
+               "-t", "-f", "-D", "-C");
+    if (!std::filesystem::exists(path))
+    {
+        lg2::error("Failed to create secret key for user {USER}", "USER",
+                   userName);
+        elog<InternalFailure>();
+        return "";
+    }
+    std::ifstream file(path);
+    if (!file.is_open())
+    {
+        lg2::error("Failed to open secret key file {PATH}", "PATH", path);
+        elog<InternalFailure>();
+        return "";
+    }
+    std::string secret;
+    std::getline(file, secret);
+    file.close();
+    if (!changeFileOwnership(path, userName))
+    {
+        elog<InternalFailure>();
+        return "";
+    }
+    return secret;
+}
+bool Users::verifyOTP(std::string otp)
+{
+    if (Totp::verify(getUserName(), otp) == PAM_SUCCESS)
+    {
+        try
+        {
+            std::filesystem::rename(
+                std::format(secretKeyTempPath, getUserName()),
+                std::format(secretKeyPath, getUserName()));
+            return true;
+        }
+        catch (const std::filesystem::filesystem_error& e)
+        {
+            lg2::error("Failed to rename file: {CODE}", "CODE", e.what());
+        }
+    }
+    return false;
+}
+
+struct MFABypassHandlers
+{
+    MultiFactorAuthType type;
+    std::function<void(Users&)> handler;
+};
+
+static void clearGoogleAuthenticator(Users& thisp)
+{
+    // thisp.isSecretKeySetup(false);
+    std::string path = std::format(secretKeyPath, thisp.getUserName());
+
+    if (std::filesystem::exists(path))
+    {
+        std::filesystem::remove(path);
+    }
+};
+static std::array<MFABypassHandlers, 2> mfaBypassHandlers{
+    MFABypassHandlers{MultiFactorAuthType::GoogleAuthenticator,
+                      clearGoogleAuthenticator},
+    MFABypassHandlers{MultiFactorAuthType::None, [](Users&) {}}};
+
+MultiFactorAuthType
+    Users::bypassedProtocol(MultiFactorAuthType value, bool skipSignal)
+{
+    auto iter = std::find_if(begin(mfaBypassHandlers), end(mfaBypassHandlers),
+                             [value](auto& v) { return v.type == value; });
+    if (iter != end(mfaBypassHandlers))
+    {
+        iter->handler(*this);
+    }
+    return Interfaces::bypassedProtocol(value, skipSignal);
+}
+
+bool Users::secretKeyIsValid() const
+{
+    std::string path = std::format(secretKeyPath, getUserName());
+    return std::filesystem::exists(path);
+}
+
+struct MFAEnableHandlers
+{
+    MultiFactorAuthType type;
+    std::function<void(Users&, bool)> handler;
+};
+
+inline void googleAuthenticatorEnabled(Users& user, bool value)
+{
+    if (!value)
+    {
+        clearGoogleAuthenticator(user);
+    }
+}
+static std::array<MFAEnableHandlers, 2> mfaEnableHandlers{
+    MFAEnableHandlers{MultiFactorAuthType::GoogleAuthenticator,
+                      googleAuthenticatorEnabled},
+    MFAEnableHandlers{MultiFactorAuthType::None, [](Users&, bool) {}}};
+
+void Users::enableMultiFactorAuth(MultiFactorAuthType type, bool value)
+{
+    auto iter = std::find_if(begin(mfaEnableHandlers), end(mfaEnableHandlers),
+                             [&type](auto& h) { return h.type == type; });
+    if (iter != end(mfaEnableHandlers))
+    {
+        iter->handler(*this, value);
+    }
 }
 
 } // namespace user

--- a/users.hpp
+++ b/users.hpp
@@ -18,7 +18,8 @@
 #include <sdbusplus/server/object.hpp>
 #include <xyz/openbmc_project/Object/Delete/server.hpp>
 #include <xyz/openbmc_project/User/Attributes/server.hpp>
-
+#include <xyz/openbmc_project/User/MultiFactorAuthConfiguration/server.hpp>
+#include <xyz/openbmc_project/User/TOTPAuthenticator/server.hpp>
 namespace phosphor
 {
 namespace user
@@ -26,8 +27,13 @@ namespace user
 
 namespace Base = sdbusplus::xyz::openbmc_project;
 using UsersIface = Base::User::server::Attributes;
+
+using TOTPAuthenticatorIface = Base::User::server::TOTPAuthenticator;
 using DeleteIface = Base::Object::server::Delete;
-using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface>;
+using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface,
+                                               TOTPAuthenticatorIface>;
+using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
+    MultiFactorAuthConfiguration::Type;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -120,6 +126,17 @@ class Users : public Interfaces
      *
      **/
     bool userPasswordExpired(void) const override;
+
+    std::string getUserName() const
+    {
+        return userName;
+    }
+    bool secretKeyIsValid() const override;
+    std::string createSecretKey() override;
+    bool verifyOTP(std::string otp) override;
+    MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
+                                         bool skipSignal) override;
+    void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
 
   private:
     std::string userName;


### PR DESCRIPTION
Enabling multi-factor authentication for BMC. This feature enables google authenticator using TOTP method.
This commit implements interface published [here](https://github.com/ openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/ User/MultiFactorAuthConfiguration.interface.yaml)
and [here](https://github.com/openbmc/phosphor-dbus-interfaces/blob/ master/yaml/xyz/openbmc_project/User/TOTPAuthenticator.interface.yaml)

The implementation supports features such as create secret key,verify TOTP token, enable system level MFA, and enable bypass options.

Currently the support is only for GoogleAuthenticator.

Change-Id: I053095763c65963ff865b487ab08f05039d2fc3a