### PR TITLE
MFA feature: Enable google authenticator

### DIFF
--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -266,6 +266,12 @@ class UserMgr : public Ifaces
     void createGroup(std::string groupName) override;
 
     void deleteGroup(std::string groupName) override;
+    MultiFactorAuthType enabled() const override
+    {
+        return MultiFactorAuthConfigurationIface::enabled();
+    }
+    MultiFactorAuthType enabled(MultiFactorAuthType value,
+                                bool skipSignal) override;
 
     virtual MultiFactorAuthType enabled(MultiFactorAuthType value,
                                         bool skipSignal) override;

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -273,9 +273,6 @@ class UserMgr : public Ifaces
     MultiFactorAuthType enabled(MultiFactorAuthType value,
                                 bool skipSignal) override;
 
-    virtual MultiFactorAuthType enabled(MultiFactorAuthType value,
-                                        bool skipSignal) override;
-
     static std::vector<std::string> readAllGroupsOnSystem();
 
   protected:

--- a/users.hpp
+++ b/users.hpp
@@ -134,11 +134,13 @@ class Users : public Interfaces
     bool secretKeyIsValid() const override;
     std::string createSecretKey() override;
     bool verifyOTP(std::string otp) override;
+    bool isGenerateSecretKeyRequired() override;
     MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
                                          bool skipSignal) override;
     void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
 
   private:
+    bool checkMfaStatus();
     std::string userName;
     UserMgr& manager;
 };


### PR DESCRIPTION
Enabling multi-factor authentication for BMC. This feature enables google authenticator using TOTP method.
This commit implements interface published [here](https://github.com/ openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/ User/MultiFactorAuthConfiguration.interface.yaml)
and [here](https://github.com/openbmc/phosphor-dbus-interfaces/blob/ master/yaml/xyz/openbmc_project/User/TOTPAuthenticator.interface.yaml)

The implementation supports features such as create secret key,verify TOTP token, enable system level MFA, and enable bypass options.

Currently the support is only for GoogleAuthenticator.

Change-Id: I053095763c65963ff865b487ab08f05039d2fc3a