### PR TITLE
UserInfo: Add secretKey status to userinfo

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1298,6 +1298,8 @@ UserInfoMap UserMgr::getUserInfo(std::string userName)
                          user.get()->userLockedForFailedAttempt());
         userInfo.emplace("UserPasswordExpired",
                          user.get()->userPasswordExpired());
+        userInfo.emplace("TOTPSecretkeyRequired",
+                         user.get()->isGenerateSecretKeyRequired());
         userInfo.emplace("RemoteUser", false);
     }
     else

--- a/users.cpp
+++ b/users.cpp
@@ -243,11 +243,11 @@ std::string Users::createSecretKey()
     -Q qr-mode (NONE, ANSI, UTF8)
     -t time-based
     -f force file
-    -D allow-reuse
+    -d disallow-reuse
     -C no-confirm no confirmation required for code provisioned
     */
     executeCmd(authAppPath.data(), "-s", path.c_str(), "-u", "-W", "-Q", "NONE",
-               "-t", "-f", "-D", "-C");
+               "-t", "-f", "-d", "-C");
     if (!std::filesystem::exists(path))
     {
         lg2::error("Failed to create secret key for user {USER}", "USER",


### PR DESCRIPTION
UserInfo shoud be populated with secretkey status so that redfish client's privilege can be degraded if secretkey is required, similar to how password expiry is handled.