### PR TITLE
Service User: Fix stale data reading for service user

### DIFF
--- a/users.cpp
+++ b/users.cpp
@@ -371,6 +371,12 @@ void Users::load(DbusSerializer& ts)
     {
         MultiFactorAuthType type =
             MultiFactorAuthConfiguration::convertTypeFromString(*protocol);
+        if (getUserName() == "service")
+        {
+            type = MultiFactorAuthType::GoogleAuthenticator;
+            ts.serialize(
+                path, MultiFactorAuthConfiguration::convertTypeToString(type));
+        }
         bypassedProtocol(type, true);
         return;
     }


### PR DESCRIPTION
There are cases where service user is enabled for MFA using old driver and the dbus properties are persisted. In the atest driver the service user is disabled for MFA but the persisted data from old driver will make the service user enabled for MFA.

This commit will fix this issue.