### PR TITLE
MFA feature: Enable google authenticator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,10 +90,11 @@ user_manager_src = [
     'user_mgr.cpp',
     'users.cpp'
 ]
-pam = cpp.find_library('pam', required: true)
+
+pam_dep = dependency('pam', required: true)
 user_manager_deps = [
      boost_dep,
-     pam,
+     pam_dep,
      sdbusplus_dep,
      phosphor_logging_dep,
      phosphor_dbus_interfaces_dep

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -974,7 +974,8 @@ bool UserMgr::userPasswordExpired(const std::string& userName)
     // All user management lock has to be based on /etc/shadow
     // TODO  phosphor-user-manager#10 phosphor::user::shadow::Lock lock{};
 
-    struct spwd spwd{};
+    struct spwd spwd
+    {};
     struct spwd* spwdPtr = nullptr;
     auto buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (buflen < -1)

--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -1718,7 +1718,7 @@ MultiFactorAuthType UserMgr::enabled(MultiFactorAuthType value, bool skipSignal)
     }
     return MultiFactorAuthConfigurationIface::enabled(value, skipSignal);
 }
-bool UserMgr::isGenerateSecretKeyRequired(const std::string& userName)
+bool UserMgr::isGenerateSecretKeyRequired(std::string userName)
 {
     if (usersList.contains(userName))
     {

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -28,6 +28,7 @@
 #include <xyz/openbmc_project/User/AccountPolicy/server.hpp>
 #include <xyz/openbmc_project/User/Manager/server.hpp>
 #include <xyz/openbmc_project/User/MultiFactorAuthConfiguration/server.hpp>
+#include <xyz/openbmc_project/User/TOTPAuthenticatorManager/server.hpp>
 
 #include <span>
 #include <string>
@@ -55,8 +56,12 @@ using AccountPolicyIface =
 using MultiFactorAuthConfigurationIface =
     sdbusplus::xyz::openbmc_project::User::server::MultiFactorAuthConfiguration;
 
+using TOTPAuthenticatorManagerIface =
+    sdbusplus::xyz::openbmc_project::User::server::TOTPAuthenticatorManager;
+
 using Ifaces = sdbusplus::server::object_t<UserMgrIface, AccountPolicyIface,
-                                           MultiFactorAuthConfigurationIface>;
+                                           MultiFactorAuthConfigurationIface,
+                                           TOTPAuthenticatorManagerIface>;
 
 using Privilege = std::string;
 using GroupList = std::vector<std::string>;
@@ -273,7 +278,7 @@ class UserMgr : public Ifaces
     }
     MultiFactorAuthType enabled(MultiFactorAuthType value,
                                 bool skipSignal) override;
-    bool isGenerateSecretKeyRequired(const std::string& userName);
+    bool isGenerateSecretKeyRequired(std::string userName) override;
     static std::vector<std::string> readAllGroupsOnSystem();
     void load();
 

--- a/user_mgr.hpp
+++ b/user_mgr.hpp
@@ -273,7 +273,7 @@ class UserMgr : public Ifaces
     }
     MultiFactorAuthType enabled(MultiFactorAuthType value,
                                 bool skipSignal) override;
-
+    bool isGenerateSecretKeyRequired(const std::string& userName);
     static std::vector<std::string> readAllGroupsOnSystem();
     void load();
 

--- a/users.cpp
+++ b/users.cpp
@@ -351,5 +351,22 @@ void Users::clearSecretKey()
     clearGoogleAuthenticator(*this);
 }
 
+void Users::load(DbusSerializer& ts)
+{
+    std::optional<std::string> protocol;
+    std::string path = std::format("{}/bypassedprotocol", userName);
+    ts.deserialize(path, protocol);
+    if (protocol)
+    {
+        MultiFactorAuthType type =
+            MultiFactorAuthConfiguration::convertTypeFromString(*protocol);
+        bypassedProtocol(type, true);
+        return;
+    }
+    bypassedProtocol(MultiFactorAuthType::None, true);
+    ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
+                           MultiFactorAuthType::None));
+}
+
 } // namespace user
 } // namespace phosphor

--- a/users.hpp
+++ b/users.hpp
@@ -36,8 +36,6 @@ using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface,
                                                TOTPAuthenticatorIface>;
 using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
     MultiFactorAuthConfiguration::Type;
-using MultiFactorAuthConfiguration =
-    sdbusplus::common::xyz::openbmc_project::user::MultiFactorAuthConfiguration;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -138,14 +136,14 @@ class Users : public Interfaces
     bool secretKeyIsValid() const override;
     std::string createSecretKey() override;
     bool verifyOTP(std::string otp) override;
-    bool isGenerateSecretKeyRequired() override;
+    bool secretKeyGenerationRequired() const override;
+    void clearSecretKey() override;
     MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
                                          bool skipSignal) override;
     void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
-    void load(DbusSerializer& serializer);
 
   private:
-    bool checkMfaStatus();
+    bool checkMfaStatus() const;
     std::string userName;
     UserMgr& manager;
 };

--- a/users.hpp
+++ b/users.hpp
@@ -36,6 +36,8 @@ using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface,
                                                TOTPAuthenticatorIface>;
 using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
     MultiFactorAuthConfiguration::Type;
+using MultiFactorAuthConfiguration =
+    sdbusplus::common::xyz::openbmc_project::user::MultiFactorAuthConfiguration;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -141,6 +143,7 @@ class Users : public Interfaces
     MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
                                          bool skipSignal) override;
     void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
+    void load(DbusSerializer& serializer);
 
   private:
     bool checkMfaStatus() const;


### PR DESCRIPTION
Enabling multi-factor authentication for BMC. This feature enables google authenticator using TOTP method.
This commit implements interface published [here][1] and [here][2]

The implementation supports features such as create secret key,verify TOTP token, enable system level MFA, and enable bypass options.

Currently the support is only for GoogleAuthenticator.

[1]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/ master/yaml/xyz/openbmc_project/User/
MultiFactorAuthConfiguration.interface.yaml

[2]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/ master/yaml/xyz/openbmc_project/User/TOTPAuthenticator.interface.yaml

Change-Id: I053095763c65963ff865b487ab08f05039d2fc3a