### PR TITLE
MFA Bypass: Serice user MFA Bypass default

### DIFF
--- a/users.cpp
+++ b/users.cpp
@@ -353,6 +353,11 @@ void Users::clearSecretKey()
 
 void Users::load(DbusSerializer& ts)
 {
+    if (userName == "service")
+    {
+        loadServiceUser(ts);
+        return;
+    }
     std::optional<std::string> protocol;
     std::string path = std::format("{}/bypassedprotocol", userName);
     ts.deserialize(path, protocol);
@@ -366,6 +371,13 @@ void Users::load(DbusSerializer& ts)
     bypassedProtocol(MultiFactorAuthType::None, true);
     ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
                            MultiFactorAuthType::None));
+}
+void Users::loadServiceUser(DbusSerializer& ts)
+{
+    std::string path = std::format("{}/bypassedprotocol", userName);
+    bypassedProtocol(MultiFactorAuthType::GoogleAuthenticator, true);
+    ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
+                           MultiFactorAuthType::GoogleAuthenticator));
 }
 
 } // namespace user

--- a/users.hpp
+++ b/users.hpp
@@ -147,6 +147,7 @@ class Users : public Interfaces
 
   private:
     bool checkMfaStatus() const;
+    void loadServiceUser(DbusSerializer& ts);
     std::string userName;
     UserMgr& manager;
 };


### PR DESCRIPTION
Fixing default MFA bypass property of service user. The code was over writtern by the recent upstream merge. This commit will put back the default MFA bypass property of service user.