### PR TITLE
Mfa generate secretkey in disabled state

### DIFF
--- a/users.cpp
+++ b/users.cpp
@@ -352,5 +352,22 @@ void Users::clearSecretKey()
     clearGoogleAuthenticator(*this);
 }
 
+void Users::load(DbusSerializer& ts)
+{
+    std::optional<std::string> protocol;
+    std::string path = std::format("{}/bypassedprotocol", userName);
+    ts.deserialize(path, protocol);
+    if (protocol)
+    {
+        MultiFactorAuthType type =
+            MultiFactorAuthConfiguration::convertTypeFromString(*protocol);
+        bypassedProtocol(type, true);
+        return;
+    }
+    bypassedProtocol(MultiFactorAuthType::None, true);
+    ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
+                           MultiFactorAuthType::None));
+}
+
 } // namespace user
 } // namespace phosphor

--- a/users.cpp
+++ b/users.cpp
@@ -354,6 +354,11 @@ void Users::clearSecretKey()
 
 void Users::load(DbusSerializer& ts)
 {
+    if (userName == "service")
+    {
+        loadServiceUser(ts);
+        return;
+    }
     std::optional<std::string> protocol;
     std::string path = std::format("{}/bypassedprotocol", userName);
     ts.deserialize(path, protocol);
@@ -368,6 +373,12 @@ void Users::load(DbusSerializer& ts)
     ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
                            MultiFactorAuthType::None));
 }
-
+void Users::loadServiceUser(DbusSerializer& ts)
+{
+    std::string path = std::format("{}/bypassedprotocol", userName);
+    bypassedProtocol(MultiFactorAuthType::GoogleAuthenticator, true);
+    ts.serialize(path, MultiFactorAuthConfiguration::convertTypeToString(
+                           MultiFactorAuthType::GoogleAuthenticator));
+}
 } // namespace user
 } // namespace phosphor

--- a/users.hpp
+++ b/users.hpp
@@ -147,6 +147,7 @@ class Users : public Interfaces
 
   private:
     bool checkMfaStatus() const;
+    void loadServiceUser(DbusSerializer& ts);
     std::string userName;
     UserMgr& manager;
 };

--- a/users.hpp
+++ b/users.hpp
@@ -36,8 +36,6 @@ using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface,
                                                TOTPAuthenticatorIface>;
 using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
     MultiFactorAuthConfiguration::Type;
-using MultiFactorAuthConfiguration =
-    sdbusplus::common::xyz::openbmc_project::user::MultiFactorAuthConfiguration;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -143,11 +141,9 @@ class Users : public Interfaces
     MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
                                          bool skipSignal) override;
     void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
-    void load(DbusSerializer& serializer);
 
   private:
     bool checkMfaStatus() const;
-    void loadServiceUser(DbusSerializer& ts);
     std::string userName;
     UserMgr& manager;
 };

--- a/users.hpp
+++ b/users.hpp
@@ -36,6 +36,8 @@ using Interfaces = sdbusplus::server::object_t<UsersIface, DeleteIface,
                                                TOTPAuthenticatorIface>;
 using MultiFactorAuthType = sdbusplus::common::xyz::openbmc_project::user::
     MultiFactorAuthConfiguration::Type;
+using MultiFactorAuthConfiguration =
+    sdbusplus::common::xyz::openbmc_project::user::MultiFactorAuthConfiguration;
 // Place where all user objects has to be created
 constexpr auto usersObjPath = "/xyz/openbmc_project/user";
 
@@ -141,6 +143,7 @@ class Users : public Interfaces
     MultiFactorAuthType bypassedProtocol(MultiFactorAuthType value,
                                          bool skipSignal) override;
     void enableMultiFactorAuth(MultiFactorAuthType type, bool value);
+    void load(DbusSerializer& serializer);
 
   private:
     bool checkMfaStatus() const;


### PR DESCRIPTION
Genrate Secretkey and Verify Secretkey apis are enabled in MFA disabled state. This is required in gloable MFA enabled path in order to make sure that MFA pipeline is working fine.
Upstream : https://gerrit.openbmc.org/c/openbmc/phosphor-user-manager/+/73053