### PR TITLE
User Mgr: Add AllowReadOnlyAccessToAllLDAPUsers D-bus property

### DIFF
--- a/phosphor-ldap-mapper/ldap_mapper_mgr.cpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.cpp
@@ -108,6 +108,8 @@ void LDAPMapperMgr::restore()
     for (auto &file : fs::directory_iterator(dir))
     {
         std::string id = file.path().filename().c_str();
+        if (id == "manager_settings")
+            continue;
         size_t idNum = std::stol(id);
         auto entryPath = std::string(mapperMgrRoot) + '/' + id;
         auto entry = std::make_unique<phosphor::user::LDAPMapperEntry>(
@@ -122,7 +124,32 @@ void LDAPMapperMgr::restore()
             }
         }
     }
+    fs::path mgrFile = fs::path(persistPath) / "manager_settings";
+    if (fs::exists(mgrFile))
+    {
+        if (!deserializeManager(mgrFile, *this))
+        {
+            log<level::ERR>("Failed to restore manager_settings, file may be corrupted.");
+        }
+    }
 }
+
+bool LDAPMapperMgr::allowReadOnlyAccessToAllLDAPUsers() const
+{
+    return allowReadOnlyAccessToAllLDAPUsersFlag;
+}
+
+bool LDAPMapperMgr::allowReadOnlyAccessToAllLDAPUsers(bool value)
+{
+    if (allowReadOnlyAccessToAllLDAPUsersFlag == value)
+        return value;
+
+     allowReadOnlyAccessToAllLDAPUsersFlag = value;
+     fs::path mgrFile = fs::path(persistPath) / "manager_settings";
+     serializeManager(*this, mgrFile);
+     return PrivilegeMapper::allowReadOnlyAccessToAllLDAPUsers(value);
+}
+
 
 } // namespace user
 } // namespace phosphor

--- a/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_mgr.hpp
@@ -61,6 +61,10 @@ class LDAPMapperMgr : public MapperMgrIface
      *  @param[in] groupName - name of the LDAP group for which privilege
      *                         mapping is to be deleted.
      */
+
+    bool allowReadOnlyAccessToAllLDAPUsers(bool value) override;
+
+    bool allowReadOnlyAccessToAllLDAPUsers() const override;
     void deletePrivilegeMapper(Id id);
 
     /** @brief Check if LDAP group privilege mapping requested is valid
@@ -90,7 +94,7 @@ class LDAPMapperMgr : public MapperMgrIface
   private:
     /** @brief sdbusplus handler */
     sdbusplus::bus::bus &bus;
-
+    bool allowReadOnlyAccessToAllLDAPUsersFlag;
     /** @brief object path for the manager object*/
     const std::string path;
 

--- a/phosphor-ldap-mapper/ldap_mapper_serialize.cpp
+++ b/phosphor-ldap-mapper/ldap_mapper_serialize.cpp
@@ -4,7 +4,7 @@
 #include <phosphor-logging/log.hpp>
 #include "config.h"
 #include "ldap_mapper_serialize.hpp"
-
+#include "ldap_mapper_mgr.hpp"
 // Register class version
 // From cereal documentation;
 // "This macro should be placed at global scope"
@@ -54,6 +54,20 @@ void load(Archive& archive, LDAPMapperEntry& entry, const std::uint32_t version)
         privilege(privilege, true);
 }
 
+template <class Archive>
+void save(Archive& archive, const  LDAPMapperMgr& mgr, const std::uint32_t version)
+{
+    archive(mgr.allowReadOnlyAccessToAllLDAPUsers());
+}
+
+template <class Archive>
+void load(Archive& archive, LDAPMapperMgr& mgr, const std::uint32_t version)
+{
+    bool flag = true;
+    archive(flag);
+    mgr.allowReadOnlyAccessToAllLDAPUsers(flag);
+}
+
 fs::path serialize(const LDAPMapperEntry& entry, Id id, const fs::path& dir)
 {
     auto path = dir / std::to_string(id);
@@ -63,6 +77,12 @@ fs::path serialize(const LDAPMapperEntry& entry, Id id, const fs::path& dir)
     return path;
 }
 
+void serializeManager(const LDAPMapperMgr& mgr, const fs::path& dir)
+{
+    std::ofstream os(dir.c_str(), std::ios::binary);
+    cereal::BinaryOutputArchive oarchive(os);
+    oarchive(mgr);
+}
 bool deserialize(const fs::path& path, LDAPMapperEntry& entry)
 {
     try
@@ -90,5 +110,31 @@ bool deserialize(const fs::path& path, LDAPMapperEntry& entry)
     }
 }
 
+bool deserializeManager(const fs::path& path, LDAPMapperMgr& mgr)
+{
+    try
+    {
+        if (fs::exists(path))
+        {
+            std::ifstream is(path.c_str(), std::ios::in | std::ios::binary);
+            cereal::BinaryInputArchive iarchive(is);
+            iarchive(mgr);
+            return true;
+        }
+        return false;
+    }
+    catch (cereal::Exception& e)
+    {
+        log<level::ERR>(e.what());
+        fs::remove(path);
+        return false;
+    }
+    catch (const std::length_error& e)
+    {
+        log<level::ERR>(e.what());
+        fs::remove(path);
+        return false;
+    }
+}
 } // namespace user
 } // namespace phosphor

--- a/phosphor-ldap-mapper/ldap_mapper_serialize.hpp
+++ b/phosphor-ldap-mapper/ldap_mapper_serialize.hpp
@@ -22,6 +22,17 @@ namespace fs = std::experimental::filesystem;
  */
 fs::path serialize(const LDAPMapperEntry& entry, Id id, const fs::path& dir);
 
+/** @brief Serialize and persist LDAP Manager  D-Bus object
+*
+*  @param[in] mgr - LDAP Manager
+*  @param[in] dir - pathname of directory where the serialized privilege
+*                   manager settings  are stored
+*
+*
+ *  @return none
+ */
+void serializeManager(const LDAPMapperMgr& mgr, const fs::path& dir);
+
 /** @brief Deserialize a persisted LDAP privilege mapper into a D-Bus object
  *
  *  @param[in] path - pathname of persisted file
@@ -31,6 +42,17 @@ fs::path serialize(const LDAPMapperEntry& entry, Id id, const fs::path& dir);
  *  @return bool - true if the deserialization was successful, false otherwise.
  */
 bool deserialize(const fs::path& path, LDAPMapperEntry& entry);
+
+/** @brief Deserialize a persisted LDAP Manager into a D-Bus object
+*
+*  @param[in] path - pathname of persisted file
+*  @param[in/out] entry - reference to  LDAP Manager entry
+*                         which is the target of deserialization.
+*
+*  @return bool - true if the deserialization was successful, false otherwise.
+*/
+
+bool deserializeManager(const fs::path& path, LDAPMapperMgr& mgr);
 
 } // namespace user
 } // namespace phosphor


### PR DESCRIPTION
User Mgr: Add AllowReadOnlyAccessToAllLDAPUsers D-bus property
THis commit adds proper serialization/deserialization of LDAPMapperMgr via cereal
and persist allowReadOnlyAccessToAllLDAPUsers flag to manager_settings
Added override methods for allowReadOnlyAccessToAllLDAPUsers

Tested by:
1.Set allowReadOnlyAccessToAllLDAPUsers flag and restart
2.Verified if its same after system comes up

Signed-off-by: Kokilambal <kokilavaradhan@gmail.com>

Change-Id: I4f2ceef5ad14366e06c327a873ec0ccd470290b9