### PR TITLE
Add support for correct lock status in manual unlock mode

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -910,9 +910,12 @@ bool UserMgr::parseFaillockForLockout(
     {
         return false;
     }
-
-    if (lastFailedAttempt +
-            static_cast<time_t>(AccountPolicyIface::accountUnlockTimeout()) <=
+    uint32_t unlockTimeout = AccountPolicyIface::accountUnlockTimeout();
+    if (unlockTimeout == 0)
+    {
+        return true;
+    }
+    if (lastFailedAttempt + static_cast<time_t>(unlockTimeout) <=
         std::time(NULL))
     {
         return false;


### PR DESCRIPTION
This commit adds support for correctly reporting user lock status when the User Unlock Method is configured as 'Manual'. Previously, the UserLockedForFailedAttempt property incorrectly reported 'false' even when the user account was locked after exceeding maximum failed login attempts.

The parseFaillockForLockout() function now includes an explicit check for manual unlock mode (AccountUnlockTimeout = 0) before performing timeout-based calculations. When AccountUnlockTimeout is zero, the function immediately returns locked status without evaluating the timeout condition, ensuring accurate status reporting for manual unlock configurations.

Tested by:
1. Setting MaxLoginAttemptBeforeLockout to 5 and AccountUnlockTimeout to 0 (manual unlock mode)
2. Making 5 failed login attempts to lock the user account
3. Verifying UserLockedForFailedAttempt property correctly reports 'true' via DBus immediately after lockout
4. Confirming user remains locked indefinitely until manual unlock via faillock reset or DBus API
5. Testing with AccountUnlockTimeout > 0 to verify automatic unlock still functions correctly after timeout period

Change-Id: I643dbe0e995c558982bb05f5fcf2708e4aaa96e4