### PR TITLE
Mask nslcd service when LDAP is disabled to prevent CI failures

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -135,6 +135,13 @@ Config::Config(sdbusplus::bus_t& bus, const char* path, const char* filePath,
     fs::create_directories(configPersistPath);
 
     configPersistPath += "/config";
+    bool loaded = deserialize();
+    if (!loaded)
+    {
+        EnableIface::enabled(false);
+    }
+    parent.startOrStopService(nslcdService, enabled());
+    this->emit_object_added();
 }
 
 void Config::certificateInstalled(sdbusplus::message_t& /*msg*/)

--- a/phosphor-ldap-config/ldap_config_mgr.cpp
+++ b/phosphor-ldap-config/ldap_config_mgr.cpp
@@ -41,11 +41,45 @@ void ConfigMgr::startOrStopService(const std::string& service, bool start)
 {
     if (start)
     {
+        try
+        {
+            auto method =
+                bus.new_method_call(systemdBusname, systemdObjPath,
+                                    systemdInterface, "UnmaskUnitFiles");
+            std::vector<std::string> units = {service};
+            method.append(units, false);
+            auto reply = bus.call(method);
+            auto reloadMethod = bus.new_method_call(
+                systemdBusname, systemdObjPath, systemdInterface, "Reload");
+            bus.call(reloadMethod);
+        }
+        catch (const sdbusplus::exception_t& ex)
+        {
+            lg2::error("Failed to unmask service {SERVICE}: {ERR}", "SERVICE",
+                       service, "ERR", ex);
+        }
         restartService(service);
     }
     else
     {
         stopService(service);
+        try
+        {
+            auto method =
+                bus.new_method_call(systemdBusname, systemdObjPath,
+                                    systemdInterface, "MaskUnitFiles");
+            std::vector<std::string> units = {service};
+            method.append(units, false, false);
+            auto reply = bus.call(method);
+            auto reloadMethod = bus.new_method_call(
+                systemdBusname, systemdObjPath, systemdInterface, "Reload");
+            bus.call(reloadMethod);
+        }
+        catch (const sdbusplus::exception_t& ex)
+        {
+            lg2::error("Failed to mask service {SERVICE}: {ERR}", "SERVICE",
+                       service, "ERR", ex);
+        }
     }
 }
 

--- a/test/ldap_config_test.cpp
+++ b/test/ldap_config_test.cpp
@@ -215,7 +215,7 @@ TEST_F(TestLDAPConfig, testRestoresDefault)
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
 
-    EXPECT_CALL(manager, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(manager, stopService("nslcd.service")).Times(3);
     EXPECT_CALL(manager, restartService("nslcd.service")).Times(0);
     EXPECT_CALL(manager, restartService("nscd.service")).Times(0);
 
@@ -247,7 +247,7 @@ TEST_F(TestLDAPConfig, testRestores)
         new MockConfigMgr(bus, LDAP_CONFIG_ROOT, configFilePath.c_str(),
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
     managerPtr->createConfig(
@@ -296,7 +296,7 @@ TEST_F(TestLDAPConfig, testLDAPServerURI)
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
 
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(3);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
 
@@ -345,7 +345,7 @@ TEST_F(TestLDAPConfig, testLDAPBindDN)
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
 
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(3);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
 
@@ -397,7 +397,7 @@ TEST_F(TestLDAPConfig, testLDAPBaseDN)
         new MockConfigMgr(bus, LDAP_CONFIG_ROOT, configFilePath.c_str(),
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(3);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
     managerPtr->createConfig(
@@ -447,7 +447,7 @@ TEST_F(TestLDAPConfig, testSearchScope)
         new MockConfigMgr(bus, LDAP_CONFIG_ROOT, configFilePath.c_str(),
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(3);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
     managerPtr->createConfig(
@@ -485,7 +485,7 @@ TEST_F(TestLDAPConfig, testLDAPType)
         new MockConfigMgr(bus, LDAP_CONFIG_ROOT, configFilePath.c_str(),
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
     managerPtr->createConfig(
@@ -525,7 +525,7 @@ TEST_F(TestLDAPConfig, testsecureLDAPRestore)
         new MockConfigMgr(bus, LDAP_CONFIG_ROOT, configFilePath.c_str(),
                           dbusPersistentFilePath.c_str(),
                           tlsCACertFilePath.c_str(), tlsCertFilePath.c_str());
-    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(1);
+    EXPECT_CALL(*managerPtr, stopService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nslcd.service")).Times(2);
     EXPECT_CALL(*managerPtr, restartService("nscd.service")).Times(1);
     managerPtr->createConfig(


### PR DESCRIPTION
This commit adds support for masking/unmasking the nslcd service based on LDAP configuration state. Previously, nslcd would attempt to start on boot with default configuration even when LDAP was disabled, resulting in service failures and core dumps that caused CI test failures when checking for failed systemd services. Added logic to explicitly mask the nslcd service when LDAP is disabled and unmasks it when LDAP is enabled. This prevents nslcd from appearing in the failed services list when LDAP is not configured, resolving CI failures in SIMICS and other test environments.

Tested by:
1. Booting system with LDAP disabled and verifying nslcd is masked    and does not appear in failed services list
2. Enabling LDAP configuration and confirming nslcd is unmasked    and starts successfully
3. Disabling LDAP and verifying nslcd is stopped and masked again
