### PR TITLE
phosphor-ldap-conf: Skip service restart when LDAP disabled

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -144,8 +144,8 @@ void Config::certificateInstalled(sdbusplus::message_t& /*msg*/)
         if (enabled())
         {
             writeConfig();
+            parent.startOrStopService(nslcdService, enabled());
         }
-        parent.startOrStopService(nslcdService, enabled());
     }
     catch (const InternalFailure& e)
     {
@@ -172,8 +172,8 @@ void Config::certificateChanged(sdbusplus::message_t& msg)
                 if (enabled())
                 {
                     writeConfig();
+                    parent.startOrStopService(nslcdService, enabled());
                 }
-                parent.startOrStopService(nslcdService, enabled());
             }
             catch (const InternalFailure& e)
             {


### PR DESCRIPTION
Fix certificate operations triggering unnecessary systemd reloads when LDAP is disabled, causing CI test failures

When LDAP client or CA certificates are installed or replaced while LDAP is disabled, the certificateInstalled() and certificateChanged() handlers now skip calling startOrStopService(). The certificate file is still stored by the certificate manager and will be automatically picked up when LDAP is enabled via writeConfig().

Tested by:
Certificate operations when LDAP is disabled - no service restart occurs. When LDAP is enabled - nslcd service restart happens properly

Change-Id: I46c55126a4edeeafddd2bdb13463819029e1faa9