### PR TITLE
phosphor-ldap-config: configure secure TLS cipher suites

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -241,6 +241,8 @@ void Config::writeConfig()
             confData << "tls_cert " << tlsCertFile.c_str() << "\n";
             confData << "tls_key " << tlsCertFile.c_str() << "\n";
         }
+        confData
+            << "tls_ciphers TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256\n";
     }
     else
     {


### PR DESCRIPTION
Configure nslcd to use modern TLS cipher suites with forward secrecy, excluding deprecated RSA key exchange. This improves security and aligns with FIPS 140-3 requirements.

The LDAP client now explicitly configures cipher suites to only offer:
- TLS 1.3: TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256
- TLS 1.2: ECDHE and DHE key exchange with AES-GCM

This excludes RSA key exchange cipher suites which lack forward secrecy and are considered weak security.

LDAP servers must support modern TLS cipher suites. Servers that only support RSA key exchange will no longer be compatible.

Testing: Verified with modern LDAP servers supporting TLS 1.3 and TLS 1.2 with ECDHE/DHE. Confirmed secure cipher negotiation.

Change-Id: I63960aea6cbad5aca6f77b0532aba1f64a4c8ed5