### PR TITLE
Configure nslcd with 4 threads to prevent crash with glibc 2.41+

### DIFF
--- a/phosphor-ldap-config/ldap_config.cpp
+++ b/phosphor-ldap-config/ldap_config.cpp
@@ -210,6 +210,7 @@ void Config::writeConfig()
     confData << "referrals off\n\n";
     confData << "uri " << ldapServerURI() << "\n\n";
     confData << "base " << ldapBaseDN() << "\n\n";
+    confData << "threads 4\n";
     confData << "binddn " << ldapBindDN() << "\n";
     if (!ldapBindPassword.empty())
     {


### PR DESCRIPTION
nslcd 0.9.8 has a thread array boundary bug that causes SIGABRT crashes during service shutdown when using default 5 threads. This is exposed by glibc 2.41's stricter pthread validation.

Configuring threads to 4 avoids the bug while maintaining sufficient performance for LDAP operations.

Tested:
- No crashes during service stop/restart cycles

Change-Id: I7e9351ab4cf89910f4b6f2df17dcbfaa05354adc